### PR TITLE
Added missing documentation following InSpec standards, resolves #11.

### DIFF
--- a/docs/resources/google_compute_address.md.erb
+++ b/docs/resources/google_compute_address.md.erb
@@ -1,0 +1,63 @@
+---
+title: About the google_compute_address Resource
+platform: gcp
+---
+
+# google\_compute\_address
+
+Use the `google_compute_address` InSpec audit resource to test properties of a single GCP compute address.
+
+<br>
+
+## Syntax
+
+A `google_compute_address` resource block declares the tests for a single GCP compute address by project, region and name.
+
+    describe google_compute_address(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      it { should exist }
+      its('name') { should eq 'compute-address' }
+      its('region') { should match 'europe-west2' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute address IP exists
+
+    describe google_compute_address(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      its('address_ip_exists')  { should be true }
+    end
+
+### Test that a GCP compute address is in a particular status
+
+    describe google_compute_address(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      its('status') { should eq "IN_USE" }
+    end
+
+### Test that a GCP compute address IP has the expected number of users
+
+    describe google_compute_address(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      its('user_count') { should eq 1 }
+    end
+
+### Test that the first user of a GCP compute address has the expected resource name
+
+    describe google_compute_address(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      its('user_resource_name') { should eq "gcp_ext_vm_name" }
+    end
+
+<br>
+
+## Properties
+
+*  `address`, `creation_timestamp`, `description`, `id`, `kind`, `name`, `region`, `status`, `users`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_firewall.md.erb
+++ b/docs/resources/google_compute_firewall.md.erb
@@ -1,0 +1,68 @@
+---
+title: About the google_compute_firewall Resource
+platform: gcp
+---
+
+# google\_compute\_firewall
+
+Use the `google_compute_firewall` InSpec audit resource to test properties of a single GCP compute compute firewall.
+
+<br>
+
+## Syntax
+
+A `google_compute_firewall` resource block declares the tests for a single GCP compute firewall by project and name.
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      it { should exist }
+      its('name') { should eq 'firewall-rule' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute firewall allows SSH access on port 22
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      its('allowed_ssh?')  { should be true }
+    end
+
+### Test that a GCP compute firewall does not allow HTTP access on port 80
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      its('allowed_http?')  { should be false }
+    end
+
+### Test that a GCP compute firewall allows HTTPS access on port 443
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      its('allowed_https?')  { should be true }
+    end
+
+### Test the direction of a GCP compute firewall e.g. "INGRESS" or "EGRESS"
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      its('direction') { should eq "INGRESS" }
+    end
+
+### Test the source IP range list for the GCP compute firewall is not open to the world
+
+    describe google_compute_firewall(project: 'chef-inspec-gcp', name: 'firewall-rule') do
+      its('source_ranges') { should_not eq ["0.0.0.0/0"] }
+    end
+
+<br>
+
+## Properties
+
+*  `allowed`, `creation_timestamp`, `description`, `direction`, `id`, `kind`, `name`, `network`, `priority`, `source_ranges`, `target_tags`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_image.md.erb
+++ b/docs/resources/google_compute_image.md.erb
@@ -1,0 +1,50 @@
+---
+title: About the google_compute_image Resource
+platform: gcp
+---
+
+# google\_compute\_image
+
+Use the `google_compute_image` InSpec audit resource to test properties of a single GCP compute image.  This resource will attempt to retrieve a project custom image then image from a family before giving up.
+
+<br>
+
+## Syntax
+
+A `google_compute_image` resource block declares the tests for a single GCP compute image by project and name.
+
+    describe google_compute_image(project: 'chef-inspec-gcp', name: 'image-1') do
+      it { should exist }
+      its('name') { should eq 'image-1' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute image is in a particular status e.g. "READY" means available for use
+
+    describe google_compute_image(project: 'chef-inspec-gcp', location: 'europe-west2', name: 'compute-address') do
+      its('status') { should eq "READY" }
+    end
+
+### Test that a GCP compute image has the expected family
+
+    describe google_compute_image(project: 'chef-inspec-gcp', name: 'ubuntu') do
+      its('family') { should match "ubuntu" }
+    end
+
+<br>
+
+## Properties
+
+*  `archive_size_bytes`, `creation_timestamp`, `description`, `disk_size_gb`, `family`, `guest_os_features`, `id`, `kind`, `label_fingerprint`, `licenses`, `name`, `raw_disk`, `source_type`, `status`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_instance.md.erb
+++ b/docs/resources/google_compute_instance.md.erb
@@ -1,0 +1,89 @@
+---
+title: About the google_compute_instance Resource
+platform: gcp
+---
+
+# google\_compute\_instance
+
+Use the `google_compute_instance` InSpec audit resource to test properties of a single GCP compute instance.
+
+<br>
+
+## Syntax
+
+A `google_compute_instance` resource block declares the tests for a single GCP instance by project, zone and name.
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      it { should exist }
+      its('name') { should eq 'inspec-test-vm' }
+      its('zone') { should match 'us-east1-b' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute instance does not exist
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm-not-there') do
+      it { should_not exist }
+    end
+
+### Test that a GCP compute instance is in the expected state ([explore possible states here](https://cloud.google.com/compute/docs/instances/checking-instance-status))
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('status') { should eq 'RUNNING' }
+    end
+
+### Test that a GCP compute instance is the expected size
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('machine_type') { should match "f1-micro" }
+    end
+
+### Test that a GCP compute instance has the expected CPU platform
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('cpu_platform') { should match "Intel" }
+    end
+
+### Test that a GCP compute instance has the expected number of attached disks
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('disk_count'){should eq 2}
+    end
+
+### Test that a GCP compute instance has the expected number of attached network interfaces
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('network_interfaces_count'){should eq 1}
+    end
+
+### Test that a GCP compute instance has the expected number of tags
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('tag_count'){should eq 1}
+    end
+
+### Test that a GCP compute instance has a single public IP address
+
+    describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'us-east1-b', name: 'inspec-test-vm') do
+      its('first_network_interface_nat_ip_exists'){ should be true }
+      its('first_network_interface_name'){ should eq "external-nat" }
+      its('first_network_interface_type'){ should eq "one_to_one_nat" }
+    end
+
+<br>
+
+## Properties
+
+*  `cpu_platform`, `creation_timestamp`, `deletion_protection`, `disks`, `id`, `kind`, `label_fingerprint`, `machine_type`, `metadata`, `name`, `network_interfaces`, `scheduling`, `start_restricted`, `status`, `tags`, `zone`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_instance_group.md.erb
+++ b/docs/resources/google_compute_instance_group.md.erb
@@ -1,0 +1,52 @@
+---
+title: About the google_compute_instance_group Resource
+platform: gcp
+---
+
+# google\_compute\_instance\_group
+
+Use the `google_compute_instance_group` InSpec audit resource to test properties of a single GCP compute instance group.
+
+<br>
+
+## Syntax
+
+A `google_compute_instance_group` resource block declares the tests for a single GCP compute instance group by project, zone and name.
+
+    describe google_compute_instance_group(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'gcp-inspec-test') do
+      it { should exist }
+      its('name') { should eq 'gcp-inspec-test' }
+      its('zone') { should match 'europe-west2-a' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute instance group has the expected size
+
+    describe google_compute_instance_group(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'gcp-inspec-test') do
+      its('size') { should eq 2 }
+    end
+
+### Test that a GCP compute instance group has a port with supplied name and value
+
+    describe google_compute_instance_group(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'gcp-inspec-test') do
+      its('port_name') { should eq "http" }
+      its('port_value') { should eq 80 }
+    end
+
+<br>
+
+## Properties
+
+*  `creation_timestamp`, `description`, `fingerprint`, `id`, `kind`, `name`, `named_ports`, `network`, `size`, `subnetwork`, `zone`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_instances.md.erb
+++ b/docs/resources/google_compute_instances.md.erb
@@ -1,0 +1,71 @@
+---
+title: About the google_compute_instances Resource
+platform: gcp
+---
+
+# google\_compute\_instances
+
+Use the `google_compute_instances` InSpec audit resource to test properties of all GCP compute instances for a project in a particular zone.
+
+<br>
+
+## Syntax
+
+A `google_compute_instances` resource block collects GCP instances by project and zone then tests that group.
+
+    describe google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a') do
+      it { should exist }
+    end
+
+Use this InSpec resource to enumerate IDs then test in-depth using `google_compute_instance`.
+
+    google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a').instance_names.each do |instance_name|
+      describe google_compute_instance(project: 'chef-inspec-gcp',  zone: 'europe-west2-a', name: instance_name) do
+        it { should exist }
+        its('zone') { should match gcp_zone }
+        its('kind') { should eq "compute#instance" }
+        its('status') { should eq 'RUNNING' }
+        its('tag_count'){ should be >= 1 }
+      end
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that there are no more than a specified number of instances in the project and zone
+
+    describe google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a') do
+      its('entries.count') { should be <= 100}
+    end
+
+### Test the exact number of instances in the project and zone
+
+    describe google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a') do
+      its('instance_ids.count') { should cmp 9 }
+    end
+
+### Test that an instance with a particular name exists in the project and zone
+
+    describe google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a') do
+      its('instance_names') { should include "my-favourite-instance" }
+    end
+
+<br>
+
+## Filter Criteria
+
+This resource currently does not support any filter criteria; it will always fetch all instances in the zone.
+
+## Properties
+
+*  `instance_id`, `instance_name`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_container_cluster.md.erb
+++ b/docs/resources/google_container_cluster.md.erb
@@ -1,0 +1,75 @@
+---
+title: About the google_container_cluster Resource
+platform: gcp
+---
+
+# google\_container\_cluster
+
+Use the `google_container_cluster` InSpec audit resource to test properties of a single GCP container cluster.
+
+<br>
+
+## Syntax
+
+A `google_container_cluster` resource block declares the tests for a single GCP container cluster by project, zone and name.
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      it { should exist }
+      its('name') { should eq 'inspec-gcp-kube-cluster' }
+      its('zone') { should match 'europe-west2-a' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP container cluster is in a particular state e.g. "RUNNING"
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      its('status') { should eq 'RUNNING' }
+    end
+
+### Test that a GCP container cluster has the expected kube master user/password
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      its('master_auth.username'){ should eq "user_name"}
+      its('master_auth.password'){ should eq "choose_something_strong"}
+    end
+
+### Test that the locations where the GCP container cluster is running match those expected
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      its('locations.sort'){should cmp ["europe-west2-a", "europe-west2-b", "europe-west2-c"].sort}
+    end
+
+### Test GCP container cluster network and subnetwork settings
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      its('network'){should eq "default"}
+      its('subnetwork'){should eq "default"}
+    end
+
+### Test GCP container cluster node pool configuration settings
+
+    describe google_container_cluster(project: 'chef-inspec-gcp', zone: 'europe-west2-a', name: 'inspec-gcp-kube-cluster') do
+      its('node_config.disk_size_gb'){should eq 100}
+      its('node_config.image_type'){should eq "COS"}
+      its('node_config.machine_type'){should eq "n1-standard-1"}
+      its('node_ipv4_cidr_size'){should eq 24}
+      its('node_pools.count'){should eq 1}
+    end
+
+<br>
+
+## Properties
+
+*  `addons_config`, `cluster_ipv4_cidr`, `create_time`, `current_master_version`, `current_node_count`, `current_node_version`, `endpoint`, `initial_cluster_version`, `initial_node_count`, `instance_group_urls`, `label_fingerprint`, `legacy_abac`, `locations`, `logging_service`, `master_auth`, `monitoring_service`, `name`, `network`, `node_config`, `node_ipv4_cidr_size`, `node_pools`, `services_ipv4_cidr`, `status`, `subnetwork`, `zone`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) is enabled for the project where the resource is located.

--- a/docs/resources/google_container_node_pool.md.erb
+++ b/docs/resources/google_container_node_pool.md.erb
@@ -1,0 +1,69 @@
+---
+title: About the google_container_node_pool Resource
+platform: gcp
+---
+
+# google\_container\_node\_pool
+
+Use the `google_container_node_pool` InSpec audit resource to test properties of a single GCP container node pool.
+
+<br>
+
+## Syntax
+
+A `google_container_node_pool` resource block declares the tests for a single GCP container node pool by project, zone, cluster name and nodepool name.
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      it { should exist }
+      its('name') { should eq 'inspec-gcp-kube-node-pool' }
+      its('zone') { should match 'europe-west2-a' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP container node pool is in a particular state e.g. "RUNNING"
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('status') { should eq 'RUNNING' }
+    end
+
+### Test GCP container node pool disk size in GB is as expected
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('node_config.disk_size_gb'){should eq 100}
+    end
+
+### Test GCP container node pool machine type is as expected
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('node_config.machine_type'){should eq "n1-standard-1"}
+    end
+
+### Test GCP container node pool node image type is as expected
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('node_config.image_type'){should eq "COS"}
+    end
+
+### Test GCP container node pool initial node count is as expected
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', zone: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('initial_node_count'){should eq 3}
+    end
+
+<br>
+
+## Properties
+
+*  `config`, `initial_node_count`, `instance_group_urls`, `management`, `name`, `status`, `version`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) is enabled for the project where the resource is located.

--- a/docs/resources/google_project.md.erb
+++ b/docs/resources/google_project.md.erb
@@ -1,0 +1,50 @@
+---
+title: About the google_project Resource
+platform: gcp
+---
+
+# google\_project
+
+Use the `google_project` InSpec audit resource to test properties of a GCP project.
+
+<br>
+
+## Syntax
+
+A `google_project` resource block declares the tests for a single GCP project by name.
+
+    describe google_project(project: 'chef-inspec-gcp') do
+      it { should exist }
+      its('name') { should eq 'chef-inspec-gcp'  }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP project has the expected project number
+
+    describe google_project(project: 'chef-inspec-gcp') do
+      its('project_number') { should eq 12345678 }
+    end
+
+### Test that a GCP project has the expected lifecycle state e.g. "ACTIVE"
+
+    describe google_project(project: 'chef-inspec-gcp') do
+      its('lifecycle_state') { should eq "ACTIVE" }
+    end
+
+<br>
+
+## Properties
+
+*  `create_time`, `lifecycle_state`, `name`, `parent`, `project_id`, `project_number`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com/) is enabled for the project.

--- a/docs/resources/google_project_iam_custom_role.md.erb
+++ b/docs/resources/google_project_iam_custom_role.md.erb
@@ -1,0 +1,50 @@
+---
+title: About the google_project_iam_custom_role Resource
+platform: gcp
+---
+
+# google\_project\_iam\_custom\_role
+
+Use the `google_project_iam_custom_role` InSpec audit resource to test properties of a GCP project IAM custom role.
+
+<br>s
+
+## Syntax
+
+A `google_project_iam_custom_role` resource block declares the tests for a single GCP project IAM custom role by project and name.
+
+    describe google_project_iam_custom_role(project: 'chef-inspec-gcp', name: 'chef-inspec-gcp-role-abcd') do
+      it { should exist }
+      its('name') { should eq 'chef-inspec-gcp-role-abcd'  }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP project IAM custom role has the expected stage in the launch lifecycle
+
+    describe google_project_iam_custom_role(project: 'chef-inspec-gcp', name: 'chef-inspec-gcp-role-abcd') do
+      its('stage') { should eq "GA" }
+    end
+
+### Test that a GCP project IAM custom role has the expected included permissions
+
+    describe google_project_iam_custom_role(project: 'chef-inspec-gcp', name: 'chef-inspec-gcp-role-abcd') do
+      its('included_permissions') { should eq ["iam.roles.list"] }
+    end
+
+<br>
+
+## Properties
+
+*  `description`, `etag`, `included_permissions`, `name`, `stage`, `title`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Identity and Access Management (IAM) API](https://console.cloud.google.com/apis/library/iam.googleapis.com/) is enabled for the project.

--- a/docs/resources/google_service_account.md.erb
+++ b/docs/resources/google_service_account.md.erb
@@ -1,0 +1,50 @@
+---
+title: About the google_service_account Resource
+platform: gcp
+---
+
+# google\_service\_account
+
+Use the `google_service_account` InSpec audit resource to test properties of a GCP project IAM service account.
+
+<br>s
+
+## Syntax
+
+A `google_service_account` resource block declares the tests for a single GCP project IAM service account by project and name.
+
+    describe google_service_account(project: 'chef-inspec-gcp', name: 'gcp-inspec-service-account') do
+      its('display_name') { should eq 'gcp-inspec-service-account' }
+      its('project_id') { should eq 'chef-inspec-gcp' }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP project IAM service account has the expected unique identifier
+
+    describe google_service_account(project: 'chef-inspec-gcp', name: 'gcp-inspec-service-account') do
+      its('unique_id') { should eq 12345678 }
+    end
+
+### Test that a GCP project IAM service account has the expected oauth2 client identifier
+
+    describe google_service_account(project: 'chef-inspec-gcp', name: 'gcp-inspec-service-account') do
+      its('oauth2_client_id') { should eq 12345678 }
+    end
+
+<br>
+
+## Properties
+
+*  `display_name`, `email`, `etag`, `name`, `oauth2_client_id`, `project_id`, `unique_id`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Identity and Access Management (IAM) API](https://console.cloud.google.com/apis/library/iam.googleapis.com/) is enabled for the project.

--- a/docs/resources/google_storage_bucket.md.erb
+++ b/docs/resources/google_storage_bucket.md.erb
@@ -1,0 +1,56 @@
+---
+title: About the google_storage_bucket Resource
+platform: gcp
+---
+
+# google\_storage\_bucket
+
+Use the `google_storage_bucket` InSpec audit resource to test properties of a GCP storage bucket.
+
+<br>s
+
+## Syntax
+
+A `google_storage_bucket` resource block declares the tests for a single GCP storage bucket by name.
+
+    describe google_storage_bucket(name: 'chef-inspec-gcp-storage-bucket-abcd') do
+      it { should exist }
+      its('name') { should eq 'chef-inspec-gcp-storage-bucket-abcd'  }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP storage bucket is in the expected location
+
+    describe google_storage_bucket(name: 'chef-inspec-gcp-storage-bucket-abcd') do
+      its('location') { should eq "EUROPE-WEST2" }
+    end
+
+### Test that a GCP storage bucket has the expected project number
+
+    describe google_storage_bucket(name: 'chef-inspec-gcp-storage-bucket-abcd') do
+      its('project_number') {should eq 12345678 }
+    end
+
+### Test that a GCP storage bucket has the expected storage class
+
+    describe google_storage_bucket(name: 'chef-inspec-gcp-storage-bucket-abcd') do
+      its('storage_class') { should eq 'STANDARD' }
+    end
+
+<br>
+
+## Properties
+
+*  `etag`, `id`, `kind`, `location`, `metageneration`, `name`, `project_number`, `storage_class`, `time_created`, `updated`
+
+s<br>
+
+
+## GCP Permissions
+
+Ensure the [Google Cloud Storage API](https://console.cloud.google.com/apis/api/storage-component.googleapis.com/) is enabled.

--- a/libraries/google_compute_image.rb
+++ b/libraries/google_compute_image.rb
@@ -8,9 +8,9 @@ module Inspec::Resources
     desc 'Verifies settings for an image'
 
     example "
-      describe google_compute_image(project: 'chef-inspec-gcp',name: 'image-1') do
+      describe google_compute_image(project: 'chef-inspec-gcp', name: 'image-1') do
         it { should exist }
-        its('name') { should eq 'inspec-test' }
+        its('name') { should eq 'image-1' }
         its('source_type') { should eq 'RAW' }
         its('family') { should eq 'inspec-test-family' }
         its('status') { should eq 'ready' }

--- a/libraries/google_compute_instances.rb
+++ b/libraries/google_compute_instances.rb
@@ -39,8 +39,8 @@ module Inspec::Resources
         @instances = @gcp.gcp_compute_client.list_instances(@project, @zone)
       end
       @instances.items.map do |instance|
-        instance_rows+=[{instance_id: instance.id,
-                        instance_name: instance.name,}]
+        instance_rows+=[{ instance_id: instance.id,
+                        instance_name: instance.name }]
       end
       @table = instance_rows
     end

--- a/libraries/google_compute_instances.rb
+++ b/libraries/google_compute_instances.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'gcp_backend'
+
+module Inspec::Resources
+  class GoogleComputeInstances < GcpResourceBase
+    name 'google_compute_instances'
+    desc 'Verifies settings for GCP compute instances in bulk'
+
+    example "
+      describe google_compute_instances(project: 'chef-inspec-gcp',  zone: 'europe-west2-a') do
+        it { should exist }
+        ...
+      end
+    "
+
+    def initialize(opts = {})
+      # Call the parent class constructor
+      super(opts)
+      @display_name = opts[:name]
+      @zone = opts[:zone]
+      @project = opts[:project]
+    end
+
+    # FilterTable setup
+    filter_table_config = FilterTable.create
+    filter_table_config.add_accessor(:where)
+    filter_table_config.add_accessor(:entries)
+    filter_table_config.add(:exist?) { |filter_table| !filter_table.entries.empty? }
+    filter_table_config.add(:count) { |filter_table| filter_table.entries.count }
+    filter_table_config.add(:instance_ids, field: :instance_id)
+    filter_table_config.add(:instance_names, field: :instance_name)
+    filter_table_config.add(:colors, field: :color, type: :simple)
+    filter_table_config.connect(self, :fetch_data)
+
+    def fetch_data
+      instance_rows = []
+      catch_gcp_errors do
+        @instances = @gcp.gcp_compute_client.list_instances(@project, @zone)
+      end
+      @instances.items.map do |instance|
+        instance_rows+=[{instance_id: instance.id,
+                        instance_name: instance.name,}]
+      end
+      @table = instance_rows
+    end
+  end
+end

--- a/test/integration/verify/controls/generic_iam_role.rb
+++ b/test/integration/verify/controls/generic_iam_role.rb
@@ -13,5 +13,6 @@ control 'gcp-generic-iam-role' do
     # stage of a role in the launch lifecycle, should be GA (can be ALPHA, BETA, or GA)
     its('stage') { should eq "GA" }
     its('name') { should match gcp_project_iam_custom_role_id }
+    its('included_permissions') { should eq ["iam.roles.list"] }
   end
 end

--- a/test/integration/verify/controls/generic_storage_bucket.rb
+++ b/test/integration/verify/controls/generic_storage_bucket.rb
@@ -12,9 +12,8 @@ control 'gcp-generic-storage-bucket-1.0' do
   describe google_storage_bucket(name: gcp_storage_bucket_name) do
     it { should exist }
     its('name') { should eq gcp_storage_bucket_name }
-    #TBD: are name & id always consistent?
     its('id') { should eq gcp_storage_bucket_name }
-    its('location') { should match gcp_location.upcase }
+    its('location') { should eq gcp_location.upcase }
     its('kind') { should eq "storage#bucket" }
     its('project_number') {should eq gcp_project_number.to_i }
     its('storage_class') { should eq 'STANDARD' }

--- a/test/integration/verify/controls/google_compute_vms.rb
+++ b/test/integration/verify/controls/google_compute_vms.rb
@@ -1,0 +1,19 @@
+title 'Virtual Machines Properties'
+
+gcp_project_id = attribute(:gcp_project_id, default: '', description: 'The GCP project identifier.')
+gcp_zone = attribute(:gcp_zone, default: '', description: 'The GCP zone being used.')
+gcp_ext_vm_data_disk_name = attribute(:gcp_ext_vm_data_disk_name, default: '', description: 'A valid GCP VM name to check for.')
+
+control 'gcp-vms-1.0' do
+
+  impact 1.0
+  title 'Ensure VMs have the correct properties in bulk'
+
+  describe google_compute_instances(project: gcp_project_id, zone: gcp_zone) do
+    it { should exist }
+    its('entries.count') { should be <= 100}
+    its('instance_ids.count') { should cmp 9 }
+    its('instance_names') { should include gcp_ext_vm_data_disk_name }
+  end
+
+end

--- a/test/integration/verify/controls/google_compute_vms_loop.rb
+++ b/test/integration/verify/controls/google_compute_vms_loop.rb
@@ -1,0 +1,20 @@
+title 'Loop over all GCP Virtual Machines'
+
+gcp_project_id = attribute(:gcp_project_id, default: '', description: 'The GCP project identifier.')
+gcp_zone = attribute(:gcp_zone, default: '', description: 'The GCP zone being used.')
+
+control 'gcp-vms-loop-1.0' do
+
+  impact 1.0
+  title 'Ensure VMs have the correct properties in bulk using google_compute_instance for detail.'
+
+  google_compute_instances(project: gcp_project_id, zone: gcp_zone).instance_names.each do |instance_name|
+    describe google_compute_instance(project: gcp_project_id, zone: gcp_zone, name: instance_name) do
+      it { should exist }
+      its('zone') { should match gcp_zone }
+      its('kind') { should eq "compute#instance" }
+      its('status') { should eq 'RUNNING' }
+      its('tag_count'){ should be >= 1 }
+    end
+  end
+end


### PR DESCRIPTION
Also minor corrections to a couple of resources.
Used InSpec FilterTable to create first plural resource for compute instances, including exammple controls and documentation.

Signed-off-by: Stuart Paterson <spaterson@chef.io>