### PR TITLE
Improve google_project#to_s output

### DIFF
--- a/libraries/google_project.rb
+++ b/libraries/google_project.rb
@@ -19,7 +19,7 @@ module Inspec::Resources
     def initialize(opts = {})
       # Call the parent class constructor
       super(opts)
-      @display_name = opts[:name]
+      @display_name = opts[:name] || opts[:project]
       catch_gcp_errors do
         @project = @gcp.gcp_project_client.get_project(opts[:project])
         create_resource_methods(@project)


### PR DESCRIPTION
The google_project resource documentation indicates that resources are
instantiated with :project, but the google_project was storing the value
of :name for use with `#to_s`. This inconsistency leads to InSpec output
like the following:

     ✔  Project  should exist
     ✔  Project  name should eq "dev-host"
     ✔  Project  parent.type should eq "folder"
     ✔  Project  parent.id should eq "743996818495"

This commit adds :project as a fallback value for `@display_name,`
ensuring that google_projects will format correctly in the InSpec
report.