### PR TITLE
Fix nil exception when no zones are returned for a region

### DIFF
--- a/libraries/google_compute_region.rb
+++ b/libraries/google_compute_region.rb
@@ -26,7 +26,7 @@ module Inspec::Resources
     # helper for returning a list of zone short names rather than fully qualified URLs e.g.
     #   https://www.googleapis.com/compute/v1/projects/spaterson-project/zones/asia-east1-a
     def zone_names
-      return false if !defined?(@region.zones)
+      return [] if @region.zones.nil?
       @region.zones.map { |zone| zone.split('/').last }
     end
 


### PR DESCRIPTION
When running the cis-gcp-benchmark-level2 profile against my gcp project, I noticed errors like this for a few controls:

![screen shot 2018-10-22 at 6 38 11 pm](https://user-images.githubusercontent.com/107378/47308496-b2688e80-d629-11e8-9517-21a4a0bf1ad3.png)

I made two changes to the PR, one to replace `false` with `[]`. Otherwise controls like these:
```
google_compute_region(project: gcp_project_id, name: region_name).zone_names.each do |zone_name|
```
will raise an error as well since they expect zone_names to be array and not boolean.

Second change is on the nil checking of `@region.zones`. It was not returning `[]`, here's my pry play:
```
[1] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> @region.zones
=> nil
[2] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> defined?(@region.zones)
=> "method"
[3] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> puts "bingo" if !defined?(@region.zones)
=> nil
[4] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> myvar=nil
=> nil
[5] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> defined?(myvar)
=> "local-variable"
[6] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> defined?(myvar2)
=> nil
[7] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> puts "bingo" if !defined?(myvar)
=> nil
[8] pry(#<#<Class:0x00007f9d7f9b7bb0>>)> puts "bingo" if !defined?(myvar2)
bingo
=> nil
```

