### PR TITLE
Fix nil checks in google_project_logging_audit_config resource

### DIFF
--- a/libraries/google_project_logging_audit_config.rb
+++ b/libraries/google_project_logging_audit_config.rb
@@ -21,12 +21,12 @@ module Inspec::Resources
         @audit_logging_configs = @gcp.gcp_project_client.get_project_iam_policy(@project)
         @default_types = []
         @default_exempted_members = {}
-        if defined?(@audit_logging_configs.audit_configs)
+        if defined?(@audit_logging_configs.audit_configs) && !@audit_logging_configs.audit_configs.nil?
           @audit_logging_configs.audit_configs.each do |service_config|
             next if service_config.service != 'allServices'
             service_config.audit_log_configs.each do |config|
               @default_types+=[config.log_type]
-              @default_exempted_members[config.log_type]=config.exempted_members if defined?(config.exempted_members)
+              @default_exempted_members[config.log_type]=config.exempted_members if defined?(config.exempted_members) && !config.exempted_members.nil?
             end
           end
         end
@@ -34,8 +34,7 @@ module Inspec::Resources
     end
 
     def exists?
-      return false if !defined? @audit_logging_configs.audit_configs
-      !@audit_logging_configs.audit_configs.nil?
+      defined?(@audit_logging_configs.audit_configs) && !@audit_logging_configs.audit_configs.nil?
     end
 
     attr_reader :default_types


### PR DESCRIPTION
Similar to https://github.com/inspec/inspec-gcp/pull/67

![screen shot 2018-10-23 at 11 35 26 am](https://user-images.githubusercontent.com/107378/47355066-4da84500-d6b8-11e8-88f7-ee3fad277f0a.png)

```
$ bundle exec inspec exec ~/git/summit-demo -t gcp:// --attrs ~/git/summit-demo/attrs.yaml
bundler: failed to load command: inspec (/usr/local/lib/ruby/gems/2.4.0/bin/inspec)
NoMethodError: undefined method `each' for nil:NilClass
  libraries/google_project_logging_audit_config.rb:25:in `block in initialize'
  libraries/gcp_backend.rb:28:in `catch_gcp_errors'
  libraries/google_project_logging_audit_config.rb:20:in `initialize'
  /Users/apop/git/inspec/lib/inspec/plugin/v1/plugin_types/resource.rb:68:in `initialize'
  /Users/apop/git/inspec/lib/inspec/resource.rb:51:in `new'
  /Users/apop/git/inspec/lib/inspec/resource.rb:51:in `block (3 levels) in create_dsl'
```

