### PR TITLE
Extra nil checks, some error values changed

### DIFF
--- a/libraries/google_compute_instance.rb
+++ b/libraries/google_compute_instance.rb
@@ -64,12 +64,12 @@ module Inspec::Resources
     end
 
     def second_disks_device_name
-      return false if !defined?(disks[1].device_name)
+      return '' if disks[1].nil? || !defined?(disks[1].device_name) || disks[1].device_name.nil?
       disks[1].device_name
     end
 
     def second_disks_kind
-      return false if !defined?(disks[1].kind)
+      return '' if disks[1].nil? || !defined?(disks[1].kind) || disks[1].kind.nil?
       disks[1].kind
     end
 
@@ -83,50 +83,50 @@ module Inspec::Resources
 
     # helper method for retrieving a disk source basename
     def disks_source_name(index = 0)
-      return false if !defined?(disks[index].source)
+      return '' if disks[index].nil? || !defined?(disks[index].source) || disks[index].source.nil?
       disks[index].source.split('/').last
     end
 
     # helper method for retrieving a disk license string
     def disks_license(disk_index = 0, license_index = 0)
-      return false if !defined?(disks[disk_index].licenses[license_index])
+      return '' if disks[disk_index].nil? || !defined?(disks[disk_index].licenses[license_index]) || disks[disk_index].licenses[license_index].nil?
       disks[disk_index].licenses[license_index].downcase
     end
 
     def machine_size
-      return false if !defined?(machine_type)
+      return '' if !defined?(machine_type) || machine_type.nil?
       machine_type.split('/').last
     end
 
     # helper for returning label keys to perform checks
     def labels_keys
-      return [] if !defined?(labels)
+      return [] if !defined?(labels) || labels.nil?
       labels.item.keys
     end
 
     # helper for returning label values to perform checks
     def labels_values
-      return [] if !defined?(labels)
+      return [] if !defined?(labels) || labels.nil?
       labels.item.values
     end
 
     def label_value_by_key(label_key)
-      return [] if !defined?(labels)
+      return [] if !defined?(labels) || labels.nil?
       labels.item[label_key]
     end
 
     def metadata_keys
-      return [] if !defined?(metadata)
+      return [] if !defined?(metadata) || metadata.nil?
       metadata.item[:items].map { |m| m[:key] }
     end
 
     def metadata_values
-      return [] if !defined?(metadata)
+      return [] if !defined?(metadata) || metadata.nil?
       metadata.item[:items].map { |m| m[:value] }
     end
 
     def metadata_value_by_key(metadata_key)
-      return [] if !defined?(metadata)
+      return [] if !defined?(metadata) || metadata.nil?
       metadata.item[:items].each do |item|
         if item[:key] == metadata_key
           return item[:value]
@@ -137,12 +137,12 @@ module Inspec::Resources
 
     def service_account_scopes
       # note instances can have only one service account defined
-      return [] if !defined?(@instance.service_accounts[0].scopes)
+      return [] if @instance.service_accounts[0].nil? || !defined?(@instance.service_accounts[0].scopes) || @instance.service_accounts[0].scopes.nil?
       @instance.service_accounts[0].scopes
     end
 
     def block_project_ssh_keys
-      return false if !defined?(@instance.metadata.items)
+      return false if !defined?(@instance.metadata.items) || @instance.metadata.items.nil?
       @instance.metadata.items.each do |element|
         return true if element.key=='block-project-ssh-keys' and element.value.casecmp('true').zero?
         return true if element.key=='block-project-ssh-keys' and element.value=='1'
@@ -151,7 +151,7 @@ module Inspec::Resources
     end
 
     def has_serial_port_disabled?
-      return false if !defined?(@instance.metadata.items)
+      return false if !defined?(@instance.metadata.items) || @instance.metadata.items.nil?
       @instance.metadata.items.each do |element|
         return true if element.key=='serial-port-enable' and element.value.casecmp('false').zero?
         return true if element.key=='serial-port-enable' and element.value=='0'
@@ -160,7 +160,7 @@ module Inspec::Resources
     end
 
     def has_disks_encrypted_with_csek?
-      return false if !defined?(@instance.disks)
+      return false if !defined?(@instance.disks) || @instance.disks.nil?
       @instance.disks.each do |disk|
         return false if !defined?(disk.disk_encryption_key)
         return false if disk.disk_encryption_key.nil?

--- a/libraries/google_compute_instance_group.rb
+++ b/libraries/google_compute_instance_group.rb
@@ -39,7 +39,7 @@ module Inspec::Resources
       # check all name/port values for a match
       return false if !defined?(named_ports) || named_ports.nil?
       named_ports.each do |named_port|
-        next if !defined?(named_port.item[key])
+        next if !defined?(named_port.item[key]) || named_port.item[key].nil?
         return named_port.item[key]
       end
       false

--- a/libraries/google_compute_network.rb
+++ b/libraries/google_compute_network.rb
@@ -37,7 +37,7 @@ module Inspec::Resources
     end
 
     def creation_timestamp_date
-      return false if !defined?(creation_timestamp)
+      return false if !defined?(creation_timestamp) || creation_timestamp.nil?
       Time.parse(creation_timestamp.to_s)
     end
 

--- a/libraries/google_compute_project_info.rb
+++ b/libraries/google_compute_project_info.rb
@@ -24,7 +24,7 @@ module Inspec::Resources
     end
 
     def has_enabled_oslogin?
-      return false if !defined?(@project_info.common_instance_metadata.items)
+      return false if !defined?(@project_info.common_instance_metadata.items) || @project_info.common_instance_metadata.items.nil?
       @project_info.common_instance_metadata.items.each do |element|
         return true if element.key=='enable-oslogin' and element.value.casecmp('true').zero?
       end
@@ -32,7 +32,7 @@ module Inspec::Resources
     end
 
     def creation_timestamp_date
-      return false if !defined?(creation_timestamp)
+      return false if !defined?(creation_timestamp) || creation_timestamp.nil?
       Time.parse(creation_timestamp.to_s)
     end
 

--- a/libraries/google_compute_region.rb
+++ b/libraries/google_compute_region.rb
@@ -26,7 +26,7 @@ module Inspec::Resources
     # helper for returning a list of zone short names rather than fully qualified URLs e.g.
     #   https://www.googleapis.com/compute/v1/projects/spaterson-project/zones/asia-east1-a
     def zone_names
-      return [] if @region.zones.nil?
+      return [] if !defined?(@region.zones) || @region.zones.nil?
       @region.zones.map { |zone| zone.split('/').last }
     end
 
@@ -35,7 +35,7 @@ module Inspec::Resources
     end
 
     def up?
-      return false if !defined?(status)
+      return false if !defined?(status) || status.nil?
       status == 'UP'
     end
 

--- a/libraries/google_compute_subnetwork.rb
+++ b/libraries/google_compute_subnetwork.rb
@@ -24,7 +24,7 @@ module Inspec::Resources
     end
 
     def creation_timestamp_date
-      return false if !defined?(creation_timestamp)
+      return false if !defined?(creation_timestamp) || creation_timestamp.nil?
       Time.parse(creation_timestamp.to_s)
     end
 

--- a/libraries/google_compute_zone.rb
+++ b/libraries/google_compute_zone.rb
@@ -26,7 +26,7 @@ module Inspec::Resources
 
     # helper method for retrieving a region name
     def region_name
-      return false if !defined?(region)
+      return '' if !defined?(region) || region.nil?
       region.split('/').last
     end
 
@@ -35,7 +35,7 @@ module Inspec::Resources
     end
 
     def up?
-      return false if !defined?(status)
+      return false if !defined?(status) || status.nil?
       status == 'UP'
     end
 

--- a/libraries/google_container_node_pool.rb
+++ b/libraries/google_container_node_pool.rb
@@ -38,17 +38,20 @@ module Inspec::Resources
     end
 
     def config_image_type
-      return false if !defined?(@nodepool.config.image_type)
+      return '' if !defined?(@nodepool.config.image_type)
+      return '' if @nodepool.config.image_type.nil?
       @nodepool.config.image_type
     end
 
     def config_service_account
-      return false if !defined?(@nodepool.config.service_account)
+      return '' if !defined?(@nodepool.config.service_account)
+      return '' if @nodepool.config.service_account.nil?
       @nodepool.config.service_account
     end
 
     def config_oauth_scopes
       return false if !defined?(@nodepool.config.oauth_scopes)
+      return false if @nodepool.config.oauth_scopes.nil?
       @nodepool.config.oauth_scopes
     end
 

--- a/libraries/google_dns_managed_zone.rb
+++ b/libraries/google_dns_managed_zone.rb
@@ -21,7 +21,7 @@ module Inspec::Resources
         @managed_zone = @gcp.gcp_client(Google::Apis::DnsV2beta1::DnsService).get_managed_zone(opts[:project], opts[:zone])
         create_resource_methods(@managed_zone)
         @key_specs={}
-        if defined?(@managed_zone.dnssec_config.default_key_specs)
+        if defined?(@managed_zone.dnssec_config.default_key_specs) && !@managed_zone.dnssec_config.default_key_specs.nil?
           @managed_zone.dnssec_config.default_key_specs.each do |spec|
             @key_specs[spec.key_type]=spec.algorithm
           end
@@ -34,7 +34,7 @@ module Inspec::Resources
     end
 
     def creation_time_date
-      return false if !defined?(@managed_zone.creation_time)
+      return false if !defined?(@managed_zone.creation_time) || @managed_zone.creation_time.nil?
       Time.parse(@managed_zone.creation_time)
     end
 

--- a/libraries/google_kms_crypto_key.rb
+++ b/libraries/google_kms_crypto_key.rb
@@ -26,33 +26,33 @@ module Inspec::Resources
     end
 
     def crypto_key_name
-      return false if !defined?(name)
+      return '' if !defined?(name) || name.nil?
       name.split('/').last
     end
 
     def create_time_date
-      return false if !defined?(create_time)
+      return false if !defined?(create_time) || create_time.nil?
       Time.parse(create_time)
     end
 
     # this is added for completeness as crypto key IAM bindings use the crypto_key_url as an identifier
     def crypto_key_url
-      return false if !defined?(name)
+      return '' if !defined?(name) || name.nil?
       name
     end
 
     def next_rotation_time_date
-      return false if !defined?(next_rotation_time)
+      return false if !defined?(next_rotation_time) || next_rotation_time.nil?
       Time.parse(next_rotation_time)
     end
 
     def primary_create_time_date
-      return false if !defined?(primary.create_time)
+      return false if !defined?(primary.create_time) || primary.create_time.nil?
       Time.parse(primary.create_time)
     end
 
     def rotation_period_seconds
-      return false if !defined?(rotation_period)
+      return 0 if !defined?(rotation_period) || rotation_period.nil?
       result = nil
       conversion = { 's'=>1, 'm'=>60, 'h'=>60*60, 'd'=>24*60*60 }
       conversion.each do |time_unit, multiplier|
@@ -63,12 +63,12 @@ module Inspec::Resources
     end
 
     def primary_name
-      return false if !defined?(primary.name)
+      return '' if !defined?(primary.name) || primary.name.nil?
       primary.name
     end
 
     def primary_state
-      return false if !defined?(primary.state)
+      return false if !defined?(primary.state) || primary.state.nil?
       primary.state
     end
 

--- a/libraries/google_kms_key_ring.rb
+++ b/libraries/google_kms_key_ring.rb
@@ -26,18 +26,18 @@ module Inspec::Resources
     end
 
     def key_ring_name
-      return false if !defined?(name)
+      return '' if !defined?(name) || name.nil?
       name.split('/').last
     end
 
     def create_time_date
-      return false if !defined?(create_time)
+      return false if !defined?(create_time) || create_time.nil?
       Time.parse(create_time)
     end
 
     # this is added for completeness as key ring IAM bindings use the key_ring_url as an identifier
     def key_ring_url
-      return false if !defined?(name)
+      return '' if !defined?(name) || name.nil?
       name
     end
 

--- a/libraries/google_project.rb
+++ b/libraries/google_project.rb
@@ -27,7 +27,7 @@ module Inspec::Resources
     end
 
     def label_value_by_key(label_key)
-      return [] if !defined?(labels)
+      return [] if !defined?(labels) || labels.nil?
       labels.item[label_key]
     end
 

--- a/libraries/google_project_alert_policies.rb
+++ b/libraries/google_project_alert_policies.rb
@@ -37,7 +37,7 @@ module Inspec::Resources
       @policies.alert_policies.map do |policy|
         policy_filters = []
         policy.conditions.each do |condition|
-          next if !defined?(condition.condition_threshold.filter)
+          next if !defined?(condition.condition_threshold.filter) || condition.condition_threshold.filter.nil?
           policy_filters+=[condition.condition_threshold.filter]
         end
 

--- a/libraries/google_project_alert_policy.rb
+++ b/libraries/google_project_alert_policy.rb
@@ -25,7 +25,7 @@ module Inspec::Resources
     end
 
     def enabled?
-      return false if !defined?(@policy.enabled)
+      return false if !defined?(@policy.enabled) || @policy.enabled.nil?
       @policy.enabled
     end
 

--- a/libraries/google_project_alert_policy_condition.rb
+++ b/libraries/google_project_alert_policy_condition.rb
@@ -30,31 +30,31 @@ module Inspec::Resources
     end
 
     def condition_for_filter(filter)
-      return nil if !defined?(@policy_result.conditions)
+      return nil if !defined?(@policy_result.conditions) || @policy_result.conditions.nil?
       @policy_result.conditions.each do |condition|
-        next if !defined?(condition.condition_threshold.filter)
+        next if !defined?(condition.condition_threshold.filter) || condition.condition_threshold.filter.nil?
         return condition if condition.condition_threshold.filter == filter
       end
       nil
     end
 
     def condition_threshold_value
-      return false if !defined?(@condition.condition_threshold.threshold_value)
+      return false if !defined?(@condition.condition_threshold.threshold_value) || @condition.condition_threshold.threshold_value.nil?
       @condition.condition_threshold.threshold_value
     end
 
     def aggregation_alignment_period
-      return false if !defined?(@condition.condition_threshold.aggregations[0].alignment_period)
+      return false if !defined?(@condition.condition_threshold.aggregations[0].alignment_period) || @condition.condition_threshold.aggregations[0].alignment_period.nil?
       @condition.condition_threshold.aggregations[0].alignment_period
     end
 
     def aggregation_per_series_aligner
-      return false if !defined?(@condition.condition_threshold.aggregations[0].per_series_aligner)
+      return false if !defined?(@condition.condition_threshold.aggregations[0].per_series_aligner) || @condition.condition_threshold.aggregations[0].per_series_aligner.nil?
       @condition.condition_threshold.aggregations[0].per_series_aligner
     end
 
     def aggregation_cross_series_reducer
-      return false if !defined?(@condition.condition_threshold.aggregations[0].cross_series_reducer)
+      return false if !defined?(@condition.condition_threshold.aggregations[0].cross_series_reducer) || @condition.condition_threshold.aggregations[0].cross_series_reducer.nil?
       @condition.condition_threshold.aggregations[0].cross_series_reducer
     end
 

--- a/libraries/google_project_logging_audit_config.rb
+++ b/libraries/google_project_logging_audit_config.rb
@@ -21,7 +21,7 @@ module Inspec::Resources
         @audit_logging_configs = @gcp.gcp_project_client.get_project_iam_policy(@project)
         @default_types = []
         @default_exempted_members = {}
-        if defined?(@audit_logging_configs.audit_configs) && !@audit_logging_configs.audit_configs.nil?
+        if defined?(@audit_logging_configs.audit_configs) && @audit_logging_configs.audit_configs.class.to_s == 'Array'
           @audit_logging_configs.audit_configs.each do |service_config|
             next if service_config.service != 'allServices'
             service_config.audit_log_configs.each do |config|

--- a/libraries/google_sql_database_instance.rb
+++ b/libraries/google_sql_database_instance.rb
@@ -36,12 +36,12 @@ module Inspec::Resources
     end
 
     def authorized_networks
-      return [] if !defined?(@database.settings.ip_configuration.authorized_networks)
-      @database.settings.ip_configuration.authorized_networks
+      return [] if !defined?(@database.settings.ip_configuration.authorized_networks) || @database.settings.ip_configuration.authorized_networks.nil?
+      @database.settings.ip_configuration.authorized_networks.map(&:value)
     end
 
     def primary_ip_address
-      return false if !defined?(@database.ip_addresses[0].ip_address)
+      return '' if !defined?(@database.ip_addresses[0].ip_address) || @database.ip_addresses[0].ip_address.nil?
       @database.ip_addresses[0].ip_address
     end
 

--- a/libraries/google_storage_bucket.rb
+++ b/libraries/google_storage_bucket.rb
@@ -31,6 +31,7 @@ module Inspec::Resources
 
     def has_versioning_enabled?
       return false if !defined?(@bucket.versioning)
+      return false if @bucket.versioning.nil?
       @bucket.versioning.enabled
     end
 

--- a/libraries/google_storage_bucket_object.rb
+++ b/libraries/google_storage_bucket_object.rb
@@ -28,17 +28,17 @@ module Inspec::Resources
     end
 
     def updated_date
-      return false if !defined?(@time_updated)
+      return false if !defined?(@time_updated) || @time_updated.nil?
       Time.parse(@time_updated.to_s)
     end
 
     def time_storage_class_updated_date
-      return false if !defined?(@time_class_updated)
+      return false if !defined?(@time_class_updated) || @time_class_updated.nil?
       Time.parse(@time_class_updated.to_s)
     end
 
     def time_created_date
-      return false if !defined?(@time_created)
+      return false if !defined?(@time_created) || @time_created.nil?
       Time.parse(@time_created.to_s)
     end
 

--- a/libraries/google_user.rb
+++ b/libraries/google_user.rb
@@ -29,12 +29,12 @@ module Inspec::Resources
     end
 
     def suspended?
-      return false if !defined?(@user.suspended)
+      return false if !defined?(@user.suspended) || @user.suspended.nil?
       @user.suspended
     end
 
     def has_mfa_enabled?
-      return false if !defined?(@user.is_enrolled_in2_sv)
+      return false if !defined?(@user.is_enrolled_in2_sv) || @user.is_enrolled_in2_sv.nil?
       @user.is_enrolled_in2_sv
     end
 


### PR DESCRIPTION
Follow up after updating two resources here:
https://github.com/inspec/inspec-gcp/pull/67
https://github.com/inspec/inspec-gcp/pull/68

this PR goes over all resources to complement `defined?` with `nil?` checks

This is why:
```
[3] pry(#<#<Class:0x00007ffe9162b028>>)> @region.zones
=> ["https://www.googleapis.com/compute/v1/projects/alex-pop-project/zones/asia-east1-a",
 "https://www.googleapis.com/compute/v1/projects/alex-pop-project/zones/asia-east1-b",
 "https://www.googleapis.com/compute/v1/projects/alex-pop-project/zones/asia-east1-c"]
[4] pry(#<#<Class:0x00007ffe9162b028>>)> puts "bingo" if !defined?(@region.zones)
=> nil
[5] pry(#<#<Class:0x00007ffe9162b028>>)> exit
[1] pry(#<#<Class:0x00007ffe9162b028>>)> @region.zones
=> nil
[2] pry(#<#<Class:0x00007ffe9162b028>>)> puts "bingo" if !defined?(@region.zones)
=> nil
[3] pry(#<#<Class:0x00007ffe9162b028>>)> puts "bingo" if @region.zones.nil?
bingo
=> nil
[4] pry(#<#<Class:0x00007ffe9162b028>>)>

[7] pry(main)> puts "bingo" if !defined?(myvariable)
bingo
=> nil
[8] pry(main)> myvariable.nil?
NameError: undefined local variable or method `myvariable' for main:Object
from (pry):2:in `__pry__'
[9] pry(main)> puts "bingo" if !defined?(myvariable) || myvariable.nil?
bingo
=> nil
[10] pry(main)> myvariable = nil
=> nil
[11] pry(main)> puts "bingo" if !defined?(myvariable) || myvariable.nil?
bingo
=> nil
```

^ `[2] pry` was not catching the `@region.zones` being nil, so we are going for `.nil?`