### PR TITLE
Added support for google_compute_region_instance_group_manager

### DIFF
--- a/docs/resources/google_compute_region_instance_group_manager.md
+++ b/docs/resources/google_compute_region_instance_group_manager.md
@@ -1,0 +1,49 @@
+---
+title: About the google_compute_region_instance_group_manager Resource
+platform: gcp
+---
+
+# google\_compute\_region\_instance\_group\_manager
+
+Use the `google_compute_region_instance_group_manager` InSpec audit resource to test properties of a single multi-zone GCP compute instance group.
+
+<br>
+
+## Syntax
+
+A `google_compute_region_instance_group_manager` resource block declares the tests for a single GCP compute instance group by project, region and name.
+
+    describe google_compute_region_instance_group_manager(project: 'chef-inspec-gcp', region: 'europe-west2', name: 'gcp-inspec-test') do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP compute region instance group manager has the expected size
+
+    describe google_compute_region_instance_group_manager(project: 'chef-inspec-gcp', region: 'europe-west2', name: 'gcp-inspec-test') do
+      its('target_size') { should eq 2 }
+    end
+
+### Test that a GCP compute region instance group manager has a port with supplied name and value
+
+    describe google_compute_region_instance_group_manager(project: 'chef-inspec-gcp', region: 'europe-west2', name: 'gcp-inspec-test') do
+      its('named_ports') { should include "http" }
+    end
+
+<br>
+
+## Properties
+
+* `base_instance_name`, `creation_timestamp`, `current_actions`, `description`, `fingerprint`, `id`, `instance_group`, `instance_template`, `kind`, `name`, `named_ports`, `region`, `self_link`, `target_pools`, `target_size`, `region`
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/docs/resources/google_compute_region_instance_group_managers.md
+++ b/docs/resources/google_compute_region_instance_group_managers.md
@@ -1,0 +1,71 @@
+---
+title: About the google_compute_region_instance_group_managers Resource
+platform: gcp
+---
+
+# google\_compute\_region\_instance\_group\_managers
+
+Use the `google_compute_region_instance_group_managerss` InSpec audit resource to test properties of all, or a filtered group of, GCP compute instance groups for a project in a particular region.
+
+<br>
+
+## Syntax
+
+A `google_compute_region_instance_group_managers` resource block collects GCP instance groups by project and region, then tests that group.
+
+    describe google_compute_region_instance_group_managers(project: 'chef-inspec-gcp') do
+      it { should exist }
+    end
+
+Use this InSpec resource to enumerate IDs then test in-depth using `google_compute_instance_group`.
+
+    google_compute_region_instance_group_managers(project: 'chef-inspec-gcp', region: 'europe-west2').instance_group_names.each do |instance_group_name|
+      describe google_compute_instance_group(project: 'chef-inspec-gcp', region: 'europe-west2', instance_group: instance_group_name) do
+        it { should exist }
+      end
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that there are no more than a specified number of instance groups available for the project
+
+    describe google_compute_region_instance_group_managers(project: 'chef-inspec-gcp', region: 'europe-west2') do
+      its('count') { should be <= 100}
+    end
+
+### Test that an expected instance_group is available for the project
+
+    describe google_compute_region_instance_group_managers(project: 'chef-inspec-gcp', region: 'europe-west2') do
+      its('instance_group_names') { should include "my-instance-group-name" }
+    end
+
+### Test that a subset of all instance_groups matching "mig*" have size greater than zero
+
+    google_compute_region_instance_group_managers(project: 'chef-inspec-gcp', region: 'europe-west2').where(instance_group_name: /^mig/).instance_group_names.each do |instance_group_name|
+      describe google_compute_instance_group(project: 'chef-inspec-gcp', region: 'europe-west2', name: instance_group_name) do
+        it { should exist }
+        its('target_size') { should be > 0 }
+      end
+    end
+    
+<br>
+
+## Filter Criteria
+
+This resource supports the following filter criteria:  `instance_group_id` and `instance_group_name`. Any of these may be used with `where`, as a block or as a method.
+
+## Properties
+
+*  `instance_group_ids` - an array of google_compute_instance_group identifier integers
+*  `instance_group_names` - an array of google_compute_instance_group name strings
+
+<br>
+
+
+## GCP Permissions
+
+Ensure the [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com/) is enabled for the project where the resource is located.

--- a/libraries/google_compute_region_instance_group_manager.rb
+++ b/libraries/google_compute_region_instance_group_manager.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'gcp_backend'
+
+module Inspec::Resources
+  class GoogleComputeRegionInstanceGroupManager < GcpResourceBase
+    name 'google_compute_region_instance_group_manager'
+    desc 'Verifies settings for a compute instance group manager'
+
+    example "
+      describe google_compute_region_instance_group_manager(project: 'chef-inspec-gcp', region: 'europe-west2', name: 'gcp-inspec-test') do
+        it { should exist }
+        its('name') { should eq 'inspec-test' }
+        ...
+      end
+    "
+    def initialize(opts = {})
+      # Call the parent class constructor
+      super(opts)
+      @display_name = opts[:name]
+      @region = opts[:region]
+
+      catch_gcp_errors do
+        @instance_group_manager = @gcp.gcp_compute_client.get_region_instance_group_manager(opts[:project], @region, @display_name)
+        create_resource_methods(@instance_group_manager)
+      end
+    end
+
+    def port_name
+      find_named_ports(:name)
+    end
+    RSpec::Matchers.alias_matcher :has_port_name, :be_allow_port_name
+
+    def port_value
+      find_named_ports(:port)
+    end
+    RSpec::Matchers.alias_matcher :has_port_value, :be_allow_port_value
+
+    def find_named_ports(key = :name)
+      # check all name/port values for a match
+      return false if !defined?(named_ports) || named_ports.nil?
+      named_ports.each do |named_port|
+        next if !defined?(named_port.item[key]) || named_port.item[key].nil?
+        return named_port.item[key]
+      end
+      false
+    end
+
+    def exists?
+      !@instance_group_manager.nil?
+    end
+
+    def to_s
+      "Region Instance Group Manager #{@display_name}"
+    end
+  end
+end

--- a/libraries/google_compute_region_instance_group_managers.rb
+++ b/libraries/google_compute_region_instance_group_managers.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'gcp_backend'
+
+module Inspec::Resources
+  class GoogleComputeRegionInstanceGroupManagers < GcpResourceBase
+    name 'google_compute_region_instance_group_managers'
+    desc 'Verifies settings for GCP compute region_instance_group_managers in bulk'
+
+    example "
+      describe google_compute_region_instance_group_managers(project: 'chef-inspec-gcp', region: 'europe-west2') do
+        it { should exist }
+        ...
+      end
+    "
+
+    def initialize(opts = {})
+      # Call the parent class constructor
+      super(opts)
+      @project = opts[:project]
+      @region = opts[:region]
+    end
+
+    # FilterTable setup
+    filter_table_config = FilterTable.create
+    filter_table_config.add(:instance_group_manager_ids, field: :instance_group_manager_id)
+    filter_table_config.add(:instance_group_manager_names, field: :instance_group_manager_name)
+    filter_table_config.connect(self, :fetch_data)
+
+    def fetch_data
+      instance_group_manager_rows = []
+      catch_gcp_errors do
+        @instance_group_managers = @gcp.gcp_compute_client.list_region_instance_group_managers(@project, @region)
+      end
+      return [] if !@instance_group_managers || !@instance_group_managers.items
+      @instance_group_managers.items.map do |instance_group|
+        instance_group_manager_rows+=[{ instance_group_manager_id: instance_group.id,
+                                instance_group_manager_name: instance_group.name }]
+      end
+      @table = instance_group_manager_rows
+    end
+  end
+end

--- a/test/integration/verify/controls/google_compute_region_instance_group_managers.rb
+++ b/test/integration/verify/controls/google_compute_region_instance_group_managers.rb
@@ -1,0 +1,19 @@
+title 'Google compute region instance group managers properties'
+
+gcp_project_id = attribute(:gcp_project_id, default: '', description: 'The GCP project identifier.')
+
+control 'gcp-compute-region-instance-group-managers-1.0' do
+
+  impact 1.0
+  title 'Ensure compute regional instance group managers have the correct properties in bulk'
+
+  google_compute_region_instance_group_managers(project: gcp_project_id, region: 'europe-west2').instance_group_manager_names.each do |instance_group_manager_name|
+    describe google_compute_region_instance_group_manager(project: gcp_project_id, region: 'europe-west2', name: instance_group_manager_name) do 
+      it { should exist }
+      its('name') { should cmp /rigm/ }
+      its('instance_template') { should cmp /itpl/ }
+      its('target_size') { should eq 0 }
+    end
+  end
+
+end

--- a/test/integration/verify/controls/google_compute_region_instance_group_managers.rb
+++ b/test/integration/verify/controls/google_compute_region_instance_group_managers.rb
@@ -1,14 +1,15 @@
 title 'Google compute region instance group managers properties'
 
 gcp_project_id = attribute(:gcp_project_id, default: '', description: 'The GCP project identifier.')
+gcp_lb_region = attribute(:gcp_lb_region, default: '', description: 'The GCP region being used.')
 
 control 'gcp-compute-region-instance-group-managers-1.0' do
 
   impact 1.0
   title 'Ensure compute regional instance group managers have the correct properties in bulk'
 
-  google_compute_region_instance_group_managers(project: gcp_project_id, region: 'europe-west2').instance_group_manager_names.each do |instance_group_manager_name|
-    describe google_compute_region_instance_group_manager(project: gcp_project_id, region: 'europe-west2', name: instance_group_manager_name) do 
+  google_compute_region_instance_group_managers(project: gcp_project_id, region: gcp_lb_region).instance_group_manager_names.each do |instance_group_manager_name|
+    describe google_compute_region_instance_group_manager(project: gcp_project_id, region: gcp_lb_region, name: instance_group_manager_name) do
       it { should exist }
       its('name') { should cmp /rigm/ }
       its('instance_template') { should cmp /itpl/ }


### PR DESCRIPTION
This PR allow users to perform validation of regional instance groups

I updated integrations tests to create a regional instance group base on a dummy instance template. I set to 0 target size, instances are not needed for this test.