### PR TITLE
Fix dataset test display

### DIFF
--- a/libraries/google_bigquery_dataset.rb
+++ b/libraries/google_bigquery_dataset.rb
@@ -63,6 +63,10 @@ class Dataset < GcpResourceBase
   def exists?
     !@fetched.nil?
   end
+  
+  def to_s
+    "Dataset #{@name}"
+  end
 
   private
 


### PR DESCRIPTION
Per the README, this is a small enough change not to require the usual procedure. When running a test on a dataset, an internal Ruby reference to the resource is displayed instead of the dataset name. I stole this syntax from code in other library files.