### PR TITLE
Add exists? method to google_compute_address

### DIFF
--- a/libraries/google_compute_address.rb
+++ b/libraries/google_compute_address.rb
@@ -32,6 +32,10 @@ module Inspec::Resources
       !address.nil?
     end
 
+    def exists?
+      !address.nil?
+    end
+
     # How many users are there for the address
     def user_count
       users.count


### PR DESCRIPTION
This adds an `exists?` method to `google_compute_address`. The documentation for `google_compute_address` shows:

```
describe google_compute_address(project: 'chef-inspec-gcp', location: 'us-west2', name: 'gcp-inspec-test') do
        it { should exist }
end
```

but that will fail because there is no `exists?` method. This PR fixes that. 


I'm not sure if this is affected by the magic modules I see in the codebase. Also unsure if y'all would prefer if we fix the documentation since there's already an `address_ip_exists` method.

Let me know if this is the right approach and I can also look into adding tests!