### PR TITLE
Add project ID to new MM terraform resources.  Inject random name for…

### DIFF
--- a/test/integration/build/gcp-mm.tf
+++ b/test/integration/build/gcp-mm.tf
@@ -669,6 +669,7 @@ resource "google_ml_engine_model" "inspec-gcp-model" {
 }
 
 resource "google_compute_firewall" "dataproc" {
+  project = var.gcp_project_id
   name    = "dataproc-firewall"
   network = "${google_compute_network.dataproc.name}"
 
@@ -688,6 +689,7 @@ resource "google_compute_firewall" "dataproc" {
 }
 
 resource "google_compute_network" "dataproc" {
+  project = var.gcp_project_id
   name = "dataproc-network"
 }
 

--- a/test/integration/configuration/gcp_inspec_config.rb
+++ b/test/integration/configuration/gcp_inspec_config.rb
@@ -41,7 +41,7 @@ module GCPInspecConfig
       # We need to randomize the name of this role to avoid e.g.
       #    Error 400: You can't create a role with role_id (gcp_inspec_project_custom_role_id) where there is an existing role with that role_id in a deleted state.
       :gcp_project_iam_custom_role_id => "gcp_inspec_custom_role_id_#{add_random_string}",
-      :gcp_compute_disk_name => "gcp-inspec-compute-disk-name",
+      :gcp_compute_disk_name => "gcp-inspec-disk-#{add_random_string}",
       :gcp_compute_disk_type => "pd-standard",
       :gcp_compute_disk_image => "ubuntu-os-cloud/ubuntu-1604-lts",
       :gcp_ext_vm_data_disk_address_name => "gcp-inspec-generic-ext-compute-data-disk-address",


### PR DESCRIPTION
… compute disk that often fails to be cleaned up during CI.

Signed-off-by: Stuart Paterson <spaterson@chef.io>