### PR TITLE
This resource is a singleton and is only driven off one unique key, "…

### DIFF
--- a/docs/resources/google_organization.md
+++ b/docs/resources/google_organization.md
@@ -13,17 +13,12 @@ Use the `google_organization` InSpec audit resource to test properties of a GCP 
 
 Google organization have a name, display name (or domain) and lifecycle state. For more info, please see [here](https://cloud.google.com/resource-manager/docs/creating-managing-organization).
 
-A `google_organization` resource block declares the tests for a single GCP organization identified by `display_name` or `name`:
+A `google_organization` resource block declares the tests for a single GCP organization identified by `name`:
 
-    describe google_organization(display_name: 'google.com') do
+    describe google_organization(display_name: 'organizations/1234') do
       it { should exist }
       its('name') { should eq 'organizations/1234'  }
       its('display_name') { should eq 'google.com' }
-    end
-
-    describe google_organization(name: 'organizations/1234') do
-      it { should exist }
-      its('name') { should eq 'google.com'  }
       its('lifecycle_state') { should eq 'ACTIVE' }
     end
 

--- a/libraries/google_organization.rb
+++ b/libraries/google_organization.rb
@@ -17,11 +17,10 @@ module Inspec::Resources
     "
     def initialize(opts = {})
       super(opts)
-      if opts[:name]
-        catch_gcp_errors do
-          @organization = @gcp.gcp_project_client.get_organization(opts[:name])
-          create_resource_methods(@organization)
-        end
+      raise Inspec::Exceptions::ResourceFailed, "google_organization is missing mandatory property 'name'" if opts[:name].nil?
+      catch_gcp_errors do
+        @organization = @gcp.gcp_project_client.get_organization(opts[:name])
+        create_resource_methods(@organization)
       end
     end
 

--- a/libraries/google_organization.rb
+++ b/libraries/google_organization.rb
@@ -8,7 +8,7 @@ module Inspec::Resources
     desc 'Verifies settings for an organization'
 
     example "
-      describe google_organization(name: 'google.com') do
+      describe google_organization(name: 'organizations/1234') do
         it { should exist }
         its('name') { should eq 'organizations/1234' }
         its('display_name') { should eq 'google.com' }
@@ -17,10 +17,11 @@ module Inspec::Resources
     "
     def initialize(opts = {})
       super(opts)
-      @display_name = opts[:name] || opts[:display_name]
-      catch_gcp_errors do
-        @organization = @gcp.gcp_project_client.get_organization(opts[:name])
-        create_resource_methods(@organization)
+      if opts[:name]
+        catch_gcp_errors do
+          @organization = @gcp.gcp_project_client.get_organization(opts[:name])
+          create_resource_methods(@organization)
+        end
       end
     end
 


### PR DESCRIPTION
…name".

Removed "display_name" as a call option as that caused a crash due to a bug in the code.
"display_name" is not gauranteed to be unique.
Signed-off-by: Adrian Daniels <adrian@chef.io>

### Description

Stops the crashing when called using display_name.
Alters the code and docs to only use name.