### PR TITLE
service_account_scopes nilclass

### DIFF
--- a/libraries/google_compute_instance.rb
+++ b/libraries/google_compute_instance.rb
@@ -137,7 +137,7 @@ module Inspec::Resources
 
     def service_account_scopes
       # note instances can have only one service account defined
-      return [] if @instance.service_accounts[0].nil? || !defined?(@instance.service_accounts[0].scopes) || @instance.service_accounts[0].scopes.nil?
+      return [] if @instance.service_accounts.nil? || @instance.service_accounts[0].nil? || !defined?(@instance.service_accounts[0].scopes) || @instance.service_accounts[0].scopes.nil?
       @instance.service_accounts[0].scopes
     end
 


### PR DESCRIPTION
### Description

If a `google_compute_instance` has no service account scopes assigned, the following logic:

```
    describe "[#{gcp_project_id}] Instance #{instance[:zone]}/#{instance[:name]}" do
      subject { google_compute_instance(project: gcp_project_id, zone: instance[:zone], name: instance[:name]) }
      its('service_account_scopes') { should_not include 'https://www.googleapis.com/auth/cloud-platform' }
    end
```

causes:

```
     ×  [my-project] Instance us-central1-f/my-instance service_account_scopes 
     undefined method `[]' for nil:NilClass
```

This adds a quick check to see if that dynamic method is available before seeing what's in the array.

### Issues Resolved

N/A
