### PR TITLE
Use SqlV1beta4 instead of SqladminV1beta4

### DIFF
--- a/libraries/google_sql_database_instance.rb
+++ b/libraries/google_sql_database_instance.rb
@@ -19,7 +19,7 @@ module Inspec::Resources
       super(opts)
       @display_name = opts[:database]
       catch_gcp_errors do
-        @database = @gcp.gcp_client(Google::Apis::SqladminV1beta4::SQLAdminService).get_instance(opts[:project], opts[:database])
+        @database = @gcp.gcp_client(Google::Apis::SqlV1beta4::SQLAdminService).get_instance(opts[:project], opts[:database])
         create_resource_methods(@database)
       end
     end


### PR DESCRIPTION
### Description

Switches the CloudSQL API client to use Google::Apis::SqlV1beta4::SQLAdminService instead of Google::Apis::SqladminV1beta4::SQLAdminService. From the outside this looks like a straight-up replacement with a more up-to-date API class.

I specifically required access to the new API class so as to check the [disk_encryption_configuration](https://googleapis.dev/ruby/google-api-client/latest/Google/Apis/SqlV1beta4/DatabaseInstance.html#disk_encryption_configuration-instance_method), which was not available on the old class.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
