### PR TITLE
Adjusting examples to use updated lib name

### DIFF
--- a/docs/resources/google_iam_service_account.md
+++ b/docs/resources/google_iam_service_account.md
@@ -8,18 +8,18 @@ A `google_iam_service_account` is used to test a Google ServiceAccount resource
 
 ## Examples
 ```
-describe google_iam_service_account(project: 'chef-gcp-inspec', name: "display-name@project-id.iam.gserviceaccount.com") do
+describe google_service_account(project: 'chef-gcp-inspec', name: "display-name@project-id.iam.gserviceaccount.com") do
   it { should exist }
   its('display_name') { should cmp '' }
 end
 
-describe google_iam_service_account(project: 'chef-gcp-inspec', name: "nonexistent@project-id.iam.gserviceaccount.com") do
+describe google_service_account(project: 'chef-gcp-inspec', name: "nonexistent@project-id.iam.gserviceaccount.com") do
   it { should_not exist }
 end
 ```
 
 ## Properties
-Properties that can be accessed from the `google_iam_service_account` resource:
+Properties that can be accessed from the `google_service_account` resource:
 
 
   * `name`: The name of the service account.


### PR DESCRIPTION
Using example results in - 

```[2020-09-10T10:40:32-04:00] ERROR: Failed to load profile inspec-dc-gcp: Failed to load source for controls/iam.rb: undefined method `google_iam_service_account' for #<Inspec::ControlEvalContext:0x00007ffd7fb2b130>

Profile:         GCP InSpec Profile (inspec-dc-gcp)
Version:         0.1.0
Failure Message: Failed to load source for controls/iam.rb: undefined method `google_iam_service_account' for #<Inspec::ControlEvalContext:0x00007ffd7fb2b130>```

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec GCP](https://github.com/inspec/inspec-gcp/CONTRIBUTING.md) document before 
submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
