### PR TITLE
Conditionally pin chef-utils on ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ gem 'inifile'
 gem 'inspec-bin', '4.16.0'
 gem 'rubocop', '>= 0.77.0'
 
+if Gem.ruby_version.to_s.start_with?("2.5")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+end
+
 group :development do
   gem 'github_changelog_generator'
   gem 'pry-coolline'


### PR DESCRIPTION
Gets the Ruby 2.5 tests to pass again, using Bundler.

