### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,7 +17,8 @@ github:
   - "Version: Bump Major"
 
  version_tag_format: v{{version}}
- release_branch:
+
+release_branches:
   - master
  
 changelog:
@@ -27,15 +28,17 @@ changelog:
   - "Type: Enhancement": "Enhancements"
   - "Type: Bug": "Bug Fixes"
 
-merge_actions:
- - built_in:bump_version:
-    ignore_labels:
-     - "Version: Skip Bump"
-     - "Expeditor: Skip All"
- - bash:.expeditor/update_version.sh:
-    only_if: built_in:bump_version
- - built_in:update_changelog:
-    ignore_labels:
-     - "Changelog: Skip Update"
-     - "Expeditor: Skip All"
+subscriptions:
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+     - built_in:bump_version:
+        ignore_labels:
+         - "Version: Skip Bump"
+         - "Expeditor: Skip All"
+     - bash:.expeditor/update_version.sh:
+        only_if: built_in:bump_version
+     - built_in:update_changelog:
+        ignore_labels:
+         - "Changelog: Skip Update"
+         - "Expeditor: Skip All"
 


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii) Release branches are a first-class concept in Expeditor, and should be represented as such.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
