### PR TITLE
RESOURCE-356 add-superclass-resource-id-method-for-gcp

### DIFF
--- a/libraries/gcp_backend.rb
+++ b/libraries/gcp_backend.rb
@@ -29,6 +29,10 @@ class GcpResourceBase < Inspec.resource(1)
     @failed_resource
   end
 
+  def resource_id
+    @connection.resource_id
+  end
+
   # Intercept GCP exceptions
   def catch_gcp_errors
     yield
@@ -248,8 +252,19 @@ class GcpApiConnection
     result = JSON.parse(response.body)
     raise_if_errors result, %w{error errors}, 'message'
     raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
+    fetch_id result
     result
   end
+
+  def fetch_id(result)
+    if result.key?('id')
+      @resource_id = result['id']
+    else
+      @resource_id = result['name']
+    end
+
+  end
+  attr_reader :resource_id
 
   def raise_if_errors(response, err_path, msg_field)
     errors = self.class.navigate(response, err_path)


### PR DESCRIPTION
Signed-off-by: sa-progress <samir.anand@progress.com>

### Description

-  Common way to find resource ids for all the resources

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec GCP](https://github.com/inspec/inspec-gcp/CONTRIBUTING.md) document before 
submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
