### PR TITLE
Allow more flexibility to GOOGLE_APPLICATION_CREDENTIALS parsing

### DIFF
--- a/generate/libraries/gcp_backend.rb
+++ b/generate/libraries/gcp_backend.rb
@@ -191,7 +191,7 @@ end
 
 class GcpApiConnection
   def initialize
-    @service_account_file = ENV['GOOGLE_APPLICATION_CREDENTIALS']
+    @google_application_credentials = ENV['GOOGLE_APPLICATION_CREDENTIALS']
   end
 
   def fetch_auth
@@ -200,8 +200,8 @@ class GcpApiConnection
         [
           'https://www.googleapis.com/auth/cloud-platform',
         ],
-      ).from_service_account_json!(
-        @service_account_file,
+      ).from_google_credentials_json!(
+        @google_application_credentials,
       )
     end
     Network::Authorization.new.from_application_default!
@@ -362,10 +362,10 @@ module Network
       self
     end
 
-    def from_service_account_json!(service_account_file)
+    def from_google_credentials_json!(credentials_file)
       raise 'Missing argument for scopes' if @scopes.empty?
-      @authorization = ::Google::Auth::ServiceAccountCredentials.make_creds(
-        json_key_io: File.open(service_account_file),
+      @authorization = ::Google::Auth::DefaultCredentials.make_creds(
+        json_key_io: File.open(credentials_file),
         scope: @scopes,
       )
       self

--- a/libraries/gcp_backend.rb
+++ b/libraries/gcp_backend.rb
@@ -197,17 +197,17 @@ class GcpApiConnection
   def initialize
     config_name = Inspec::Config.cached.unpack_train_credentials[:host]
     ENV['CLOUDSDK_ACTIVE_CONFIG_NAME'] = config_name
-    @service_account_file = config_name.blank? && ENV['GOOGLE_APPLICATION_CREDENTIALS']
+    @google_application_credentials = config_name.blank? && ENV['GOOGLE_APPLICATION_CREDENTIALS']
   end
 
   def fetch_auth
-    unless @service_account_file.nil?
+    unless @google_application_credentials.nil?
       return Network::Authorization.new.for!(
         [
           'https://www.googleapis.com/auth/cloud-platform',
         ],
-      ).from_service_account_json!(
-        @service_account_file,
+      ).from_google_credentials_json!(
+        @google_application_credentials,
       )
     end
     Network::Authorization.new.from_application_default!
@@ -387,10 +387,10 @@ module Network
       self
     end
 
-    def from_service_account_json!(service_account_file)
+    def from_google_credentials_json!(credentials_file)
       raise 'Missing argument for scopes' if @scopes.empty?
-      @authorization = ::Google::Auth::ServiceAccountCredentials.make_creds(
-        json_key_io: File.open(service_account_file),
+      @authorization = ::Google::Auth::DefaultCredentials.make_creds(
+        json_key_io: File.open(credentials_file),
         scope: @scopes,
       )
       self


### PR DESCRIPTION
The GoogleAuth library supports creating credentials for multiple credential types. The current state of inspec-gcp limits users passing a `GOOGLE_APPLICATION_CREDENTIALS` file to only be able to use service accounts.

### Description

This allows users utilizing authentication types other than service accounts to pass an appropriate `GOOGLE_APPLICATION_CREDENTIALS` file. It is no longer recommended by Google to utilize a service account directly and Workload Identity Federation is the recommended replacement. I am trying to implement Workload Identity Federation in googleauth and utilize it with InSpec and this is one of the issues I encountered.

### Issues Resolved

This is relevant to the work I am doing in https://github.com/googleapis/google-auth-library-ruby/issues/354
