### PR TITLE
Do not raise an error when calling resource_id if @connection is nil

### DIFF
--- a/libraries/gcp_backend.rb
+++ b/libraries/gcp_backend.rb
@@ -30,7 +30,7 @@ class GcpResourceBase < Inspec.resource(1)
   end
 
   def resource_id
-    @connection.resource_id
+    @connection&.resource_id
   end
 
   # Intercept GCP exceptions


### PR DESCRIPTION
### Description

`@connection` is only set if `opts[:use_http_transport]` is set, however if that is the case then calling `resource_id` raises an error. This adds safe navigation to connection in order to avoid this error.

### Issues Resolved
This is an error I started encountering when testing changes related to https://github.com/googleapis/google-auth-library-ruby/issues/354.
