### PR TITLE
Add `paused` attribute to cloud_scheduler_job resource

### DIFF
--- a/docs/resources/google_cloud_scheduler_job.md
+++ b/docs/resources/google_cloud_scheduler_job.md
@@ -31,6 +31,10 @@ Properties that can be accessed from the `google_cloud_scheduler_job` resource:
 
   * `time_zone`: Specifies the time zone to be used in interpreting schedule. The value of this field must be a time zone name from the tz database.
 
+  * `state`: State of the job.
+
+  * `paused`: Sets the job to a paused state. Jobs default to being enabled when this property is not set.
+
   * `attempt_deadline`: The deadline for job attempts. If the request handler does not respond by this deadline then the request is cancelled and the attempt is marked as a DEADLINE_EXCEEDED failure. The failed attempt can be viewed in execution logs. Cloud Scheduler will retry the job according to the RetryConfig. The allowed duration for this deadline is: * For HTTP targets, between 15 seconds and 30 minutes. * For App Engine HTTP targets, between 15 seconds and 24 hours. * **Note**: For PubSub targets, this field is ignored - setting it will introduce an unresolvable diff. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s"
 
   * `retry_config`: By default, if a job does not complete successfully,  meaning that an acknowledgement is not received from the handler,  then it will be retried with exponential backoff according to the settings

--- a/docs/resources/google_cloud_scheduler_jobs.md
+++ b/docs/resources/google_cloud_scheduler_jobs.md
@@ -29,6 +29,8 @@ See [google_cloud_scheduler_job.md](google_cloud_scheduler_job.md) for more deta
   * `descriptions`: an array of `google_cloud_scheduler_job` description
   * `schedules`: an array of `google_cloud_scheduler_job` schedule
   * `time_zones`: an array of `google_cloud_scheduler_job` time_zone
+  * `states`: an array of `google_cloud_scheduler_job` state
+  * `pauseds`: an array of `google_cloud_scheduler_job` paused
   * `attempt_deadlines`: an array of `google_cloud_scheduler_job` attempt_deadline
   * `retry_configs`: an array of `google_cloud_scheduler_job` retry_config
   * `pubsub_targets`: an array of `google_cloud_scheduler_job` pubsub_target

--- a/libraries/google_cloud_scheduler_job.rb
+++ b/libraries/google_cloud_scheduler_job.rb
@@ -33,6 +33,8 @@ class CloudSchedulerJob < GcpResourceBase
   attr_reader :description
   attr_reader :schedule
   attr_reader :time_zone
+  attr_reader :state
+  attr_reader :paused
   attr_reader :attempt_deadline
   attr_reader :retry_config
   attr_reader :pubsub_target
@@ -52,6 +54,8 @@ class CloudSchedulerJob < GcpResourceBase
     @description = @fetched['description']
     @schedule = @fetched['schedule']
     @time_zone = @fetched['timeZone']
+    @state = @fetched['state']
+    @paused = @fetched['paused']
     @attempt_deadline = @fetched['attemptDeadline']
     @retry_config = GoogleInSpec::CloudScheduler::Property::JobRetryConfig.new(@fetched['retryConfig'], to_s)
     @pubsub_target = GoogleInSpec::CloudScheduler::Property::JobPubsubTarget.new(@fetched['pubsubTarget'], to_s)

--- a/libraries/google_cloud_scheduler_jobs.rb
+++ b/libraries/google_cloud_scheduler_jobs.rb
@@ -27,6 +27,8 @@ class CloudSchedulerJobs < GcpResourceBase
   filter_table_config.add(:descriptions, field: :description)
   filter_table_config.add(:schedules, field: :schedule)
   filter_table_config.add(:time_zones, field: :time_zone)
+  filter_table_config.add(:states, field: :state)
+  filter_table_config.add(:pauseds, field: :paused)
   filter_table_config.add(:attempt_deadlines, field: :attempt_deadline)
   filter_table_config.add(:retry_configs, field: :retry_config)
   filter_table_config.add(:pubsub_targets, field: :pubsub_target)
@@ -76,6 +78,8 @@ class CloudSchedulerJobs < GcpResourceBase
       'description' => ->(obj) { return :description, obj['description'] },
       'schedule' => ->(obj) { return :schedule, obj['schedule'] },
       'timeZone' => ->(obj) { return :time_zone, obj['timeZone'] },
+      'state' => ->(obj) { return :state, obj['state'] },
+      'paused' => ->(obj) { return :paused, obj['paused'] },
       'attemptDeadline' => ->(obj) { return :attempt_deadline, obj['attemptDeadline'] },
       'retryConfig' => ->(obj) { return :retry_config, GoogleInSpec::CloudScheduler::Property::JobRetryConfig.new(obj['retryConfig'], to_s) },
       'pubsubTarget' => ->(obj) { return :pubsub_target, GoogleInSpec::CloudScheduler::Property::JobPubsubTarget.new(obj['pubsubTarget'], to_s) },


### PR DESCRIPTION
### Description
Add `state` and `paused` attributes to the cloud scheduler job resources

Based on:
https://github.com/GoogleCloudPlatform/magic-modules/pull/6304

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
