### PR TITLE
CHEF-4288 wrong atrribute workloadMetadataConfig fixed

### DIFF
--- a/libraries/google/container/property/nodepool_config.rb
+++ b/libraries/google/container/property/nodepool_config.rb
@@ -71,7 +71,7 @@ module GoogleInSpec
           @min_cpu_platform = args['minCpuPlatform']
           @taints = GoogleInSpec::Container::Property::NodePoolConfigTaintsArray.parse(args['taints'], to_s)
           @shielded_instance_config = GoogleInSpec::Container::Property::NodePoolConfigShieldedInstanceConfig.new(args['shieldedInstanceConfig'], to_s)
-          @workload_meta_config = GoogleInSpec::Container::Property::NodePoolConfigWorkloadMetaConfig.new(args['workloadMetaConfig'], to_s)
+          @workload_meta_config = GoogleInSpec::Container::Property::NodePoolConfigWorkloadMetaConfig.new(args['workloadMetadataConfig'], to_s)
         end
 
         def to_s


### PR DESCRIPTION
### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec GCP](https://github.com/inspec/inspec-gcp/CONTRIBUTING.md) document before 
submitting.
FIx for wrong attribute provided.
older config - workloadMetaConfig changed to workloadMetadataConfig
### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
