### PR TITLE
Fixed vertex ai uri handleing-current version had no support for base…

### DIFF
--- a/libraries/gcp_backend.rb
+++ b/libraries/gcp_backend.rb
@@ -278,8 +278,11 @@ class GcpApiConnection
   end
 
   def build_uri(base_url, template, var_data)
+    region = var_data[:region]
+    # Replace {{region}} in the base_url with the extracted region for VertexAI
+    base_url_with_region = base_url.gsub('{{region}}', region)
     URI.join(
-      "#{base_url}#{expand_variables(template, var_data)}",
+      "#{base_url_with_region}#{expand_variables(template, var_data)}",
     )
   end
 


### PR DESCRIPTION
Description: Fixed vertex AI URI handling. The current version lacked support for the base URL.

Fix Details:

Before: 
    The previous version did not require the inclusion of a base URL and used a format like this: https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/acceleratorTypes/{acceleratorType}.
    After: With this fix, we now handle URIs with a base URL, such as https://{service-endpoint}/v1/{name}.
Explanation:
    In the older version, the URI structure did not require specifying the base URL (compute.googleapis.com/compute/v1) explicitly. However, in the updated version, we have added support for URIs that include the service endpoint as part of the base URL ({service-endpoint}/v1). This enhancement ensures compatibility with different URI formats, providing more flexibility in handling Vertex AI URIs.

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec GCP](https://github.com/inspec/inspec-gcp/CONTRIBUTING.md) document before 
submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
