### PR TITLE
CHEF-1895- Update googleauth to support external account type authorisation in GCP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'bundle'
 gem 'faraday', '>= 0.16.2'
-gem 'google-api-client'
+gem 'google-apis-core'
 gem 'google-cloud'
 gem 'googleauth'
 gem 'inifile'


### PR DESCRIPTION
### Description
Deprecated google-api-client and added new library respect to the changes in train repository
