### PR TITLE
Reverted version pinning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'google-api-client'
 gem 'google-cloud'
 gem 'googleauth'
 gem 'inifile'
-gem 'inspec-bin', '>= 4.16.0'
+gem 'inspec-bin', '4.16.0'
 gem 'rubocop', '>= 0.77.0'
 
 group :development do


### PR DESCRIPTION
### Description
Recent version pinning is breaking the pipeline causing the timeout error.
Since it is blocking, we are reverting the version pinning changes 

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
