### PR TITLE
CHEF-7374: Add missing properties to google_service_account_key resource

### DIFF
--- a/docs/resources/google_service_account_key.md
+++ b/docs/resources/google_service_account_key.md
@@ -54,9 +54,16 @@ Properties that can be accessed from the `google_service_account_key` resource:
     * USER_MANAGED
     * SYSTEM_MANAGED
 
+  * `key_origin`: The key origin.
+  Possible values:
+    * ORIGIN_UNSPECIFIED
+    * USER_PROVIDED
+    * GOOGLE_PROVIDED
+
   * `service_account`: The name of the serviceAccount.
 
   * `path`: The full name of the file that will hold the service account private key. The management of this file will depend on the value of sync_file parameter.  File path must be absolute.
+  * `disabled`: The key status.
 
 
 ## GCP Permissions

--- a/docs/resources/google_service_account_keys.md
+++ b/docs/resources/google_service_account_keys.md
@@ -19,7 +19,7 @@ end
     describe google_service_account_keys(project: 'sample-project', service_account: 'sample-account@sample-project.iam.gserviceaccount.com') do
       its('count') { should be <= 1000}
     end
-    
+
 ### Test that a service account with expected name is available
 
     describe google_service_account_keys(project: 'sample-project', service_account: 'sample-account@sample-project.iam.gserviceaccount.com') do
@@ -37,9 +37,11 @@ See [google_service_account_key.md](google_service_account_key.md) for more deta
   * `public_key_data`: an array of `google_service_account_key` public_key_data
   * `valid_after_times`: an array of `google_service_account_key` valid_after_time
   * `valid_before_times`: an array of `google_service_account_key` valid_before_time
+  * `key_origins`: an array of `google_iam_project_service_account_key` key_origin
   * `key_types`: an array of `google_service_account_key` key_type
   * `service_accounts`: an array of `google_service_account_key` service_account
   * `paths`: an array of `google_service_account_key` path
+  * `disableds`: an array of `google_iam_project_service_account_key` disabled
 
 ## Filter Criteria
 This resource supports all of the above properties as filter criteria, which can be used

--- a/docs/resources/google_service_account_keys.md
+++ b/docs/resources/google_service_account_keys.md
@@ -37,11 +37,11 @@ See [google_service_account_key.md](google_service_account_key.md) for more deta
   * `public_key_data`: an array of `google_service_account_key` public_key_data
   * `valid_after_times`: an array of `google_service_account_key` valid_after_time
   * `valid_before_times`: an array of `google_service_account_key` valid_before_time
-  * `key_origins`: an array of `google_iam_project_service_account_key` key_origin
+  * `key_origins`: an array of `google_service_account_key` key_origin
   * `key_types`: an array of `google_service_account_key` key_type
   * `service_accounts`: an array of `google_service_account_key` service_account
   * `paths`: an array of `google_service_account_key` path
-  * `disableds`: an array of `google_iam_project_service_account_key` disabled
+  * `disableds`: an array of `google_service_account_key` disabled
 
 ## Filter Criteria
 This resource supports all of the above properties as filter criteria, which can be used

--- a/libraries/google_service_account_key.rb
+++ b/libraries/google_service_account_key.rb
@@ -29,9 +29,11 @@ class IAMServiceAccountKey < GcpResourceBase
   attr_reader :public_key_data
   attr_reader :valid_after_time
   attr_reader :valid_before_time
+  attr_reader :key_origin
   attr_reader :key_type
   attr_reader :service_account
   attr_reader :path
+  attr_reader :disabled
 
   def initialize(params)
     super(params.merge({ use_http_transport: true }))
@@ -48,9 +50,11 @@ class IAMServiceAccountKey < GcpResourceBase
     @public_key_data = @fetched['publicKeyData']
     @valid_after_time = parse_time_string(@fetched['validAfterTime'])
     @valid_before_time = parse_time_string(@fetched['validBeforeTime'])
+    @key_origin = @fetched['keyOrigin']
     @key_type = @fetched['keyType']
     @service_account = @fetched['serviceAccount']
     @path = @fetched['path']
+    @disabled = @fetched['disabled']
   end
 
   # Handles parsing RFC3339 time string

--- a/libraries/google_service_account_keys.rb
+++ b/libraries/google_service_account_keys.rb
@@ -36,7 +36,6 @@ class IAMServiceAccountKeys < GcpResourceBase
   filter_table_config.add(:key_origins, field: :key_origin)
   filter_table_config.add(:disableds, field: :disabled)
 
-
   filter_table_config.connect(self, :table)
 
   def initialize(params = {})

--- a/libraries/google_service_account_keys.rb
+++ b/libraries/google_service_account_keys.rb
@@ -33,6 +33,9 @@ class IAMServiceAccountKeys < GcpResourceBase
   filter_table_config.add(:key_types, field: :key_type)
   filter_table_config.add(:service_accounts, field: :service_account)
   filter_table_config.add(:paths, field: :path)
+  filter_table_config.add(:key_origins, field: :key_origin)
+  filter_table_config.add(:disableds, field: :disabled)
+
 
   filter_table_config.connect(self, :table)
 
@@ -82,6 +85,8 @@ class IAMServiceAccountKeys < GcpResourceBase
       'keyType' => ->(obj) { [:key_type, obj['keyType']] },
       'serviceAccount' => ->(obj) { [:service_account, obj['serviceAccount']] },
       'path' => ->(obj) { [:path, obj['path']] },
+      'keyOrigin' => ->(obj) { [:key_origin, obj['keyOrigin']] },
+      'disabled' => ->(obj) { [:disabled, obj['disabled']] },
     }
   end
 


### PR DESCRIPTION
### Description
Add missing properties to google_service_account_key resource as per latest response received from the API.

### Issues Resolved
CHEF-7374: [GCP InSpec Resource] IAM - Project Service Account keys 
