### PR TITLE
Fix Verify Pipeline timeout issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'faraday', '>= 0.16.2'
 gem 'google-api-client'
 gem 'google-cloud'
 gem 'googleauth'
-gem 'inifile'
-gem 'inspec-bin', '4.16.0'
+# we are pinning to inspec-core-bin below 6.0 to avoid bringing licensing change in the CI
+gem 'inspec-core-bin', '>= 5.22.36', '< 6.0'
 gem 'rubocop', '>= 0.77.0'
 
 group :development do


### PR DESCRIPTION
### Description

Verify pipeline was failing due to timeout issues.
#### Fix
Removed unused gem and added latest inspec-core-bin gem
