### PR TITLE
CHEF-11234: Fix broken CI issue `can't create Thread: Operation not permitted (ThreadError)`

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -12,7 +12,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1
+        image: ruby:3.1-bullseye
 
 
 - label: run-tests-ruby-3.1
@@ -21,4 +21,4 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:3.1
+        image: ruby:3.1-bullseye


### PR DESCRIPTION
### Description

The current Docker image version (ruby:3.1) encounters a ThreadError due to restrictions imposed by libseccomp, blocking certain system calls necessary for the operation of Ruby's open3 module.

```
/usr/local/lib/ruby/3.1.0/open3.rb:223:in `detach': can't create Thread: Operation not permitted (ThreadError)
```

This PR addresses the issue encountered in the current Docker image setup by updating the Docker image version from ruby:3.1 to ruby:3.1-bullseye.

_Note: This is a workaround_

### Issues Resolved
CHEF-11234: CI is breaking for inspec, inspec-gcp, and train due to issue with docker image used for the tests

### Related Conversation
https://github.com/docker-library/python/issues/837#issuecomment-1599640563
https://github.com/docker-library/redmine/discussions/307#discussioncomment-7711691
