### PR TITLE
Fix uninitialized constant Parser::AST::Processor::Mixin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'googleauth'
 # we are pinning to inspec-core-bin below 6.0 to avoid bringing licensing change in the CI
 gem 'inspec-core-bin', '>= 5.22.36', '< 6.0'
 gem 'rubocop', '>= 0.77.0'
+gem 'parser', '< 3.3.1.0'
 
 group :development do
   gem 'github_changelog_generator'


### PR DESCRIPTION
## Description

parser 3.3.1.0 introduced https://github.com/whitequark/parser/pull/1000, which causes this failure:

```
% 
bundle exec inspec check /workdir --chef-license=accept-silent
    bundler: failed to load command: inspec (/usr/local/bundle/bin/inspec)
    /usr/local/bundle/gems/inspec-core-5.22.40/lib/inspec/utils/profile_ast_helpers.rb:7:in `<class:CollectorBase>': 
    uninitialized constant Parser::AST::Processor::Mixin (NameError)

```

Fix this by requiring the right version of the `parser` gem.

## Related Issue

Closes #[7029](https://github.com/inspec/inspec/issues/7029)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
