### PR TITLE
Deprecate active support blank method

### DIFF
--- a/libraries/gcp_backend.rb
+++ b/libraries/gcp_backend.rb
@@ -200,7 +200,8 @@ class GcpApiConnection
     @resource = resource
     config_name = Inspec::Config.cached.unpack_train_credentials[:host]
     ENV['CLOUDSDK_ACTIVE_CONFIG_NAME'] = config_name
-    @google_application_credentials = config_name.blank? && ENV['GOOGLE_APPLICATION_CREDENTIALS']
+    # deprecated active_support blank method
+    @google_application_credentials = config_name.to_s.empty? && ENV['GOOGLE_APPLICATION_CREDENTIALS']
   end
 
   def fetch_auth


### PR DESCRIPTION
### Description
InSpec GCP Profiles are failing because of active support blank method

### Error
undefined method `blank?' for nil:NilClass

### Fixes

Removed blank method dependency and added nil, empty checks.
