### PR TITLE
Rename orgpolicy properties

### DIFF
--- a/libraries/google/orgpolicy/property/policy_alternate.rb
+++ b/libraries/google/orgpolicy/property/policy_alternate.rb
@@ -13,23 +13,25 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
+require 'google/orgpolicy/property/policy_alternate_spec'
+require 'google/orgpolicy/property/policy_alternate_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyDryRunSpecRulesValues
-        attr_reader :denied_values
+      class PolicyAlternate
+        attr_reader :launch
 
-        attr_reader :allowed_values
+        attr_reader :spec
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @denied_values = args['deniedValues']
-          @allowed_values = args['allowedValues']
+          @launch = args['launch']
+          @spec = GoogleInSpec::Orgpolicy::Property::PolicyAlternateSpec.new(args['spec'], to_s)
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyDryRunSpecRulesValues"
+          "#{@parent_identifier} PolicyAlternate"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_alternate_spec.rb
+++ b/libraries/google/orgpolicy/property/policy_alternate_spec.rb
@@ -13,29 +13,33 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
+require 'google/orgpolicy/property/policy_alternate_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicySpecRulesCondition
-        attr_reader :title
+      class PolicyAlternateSpec
+        attr_reader :update_time
 
-        attr_reader :location
+        attr_reader :rules
 
-        attr_reader :expression
+        attr_reader :etag
 
-        attr_reader :description
+        attr_reader :reset
+
+        attr_reader :inherit_from_parent
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @title = args['title']
-          @location = args['location']
-          @expression = args['expression']
-          @description = args['description']
+          @update_time = args['updateTime']
+          @rules = GoogleInSpec::Orgpolicy::Property::PolicyAlternateSpecRulesArray.parse(args['rules'], to_s)
+          @etag = args['etag']
+          @reset = args['reset']
+          @inherit_from_parent = args['inheritFromParent']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicySpecRulesCondition"
+          "#{@parent_identifier} PolicyAlternateSpec"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_alternate_spec_rules.rb
+++ b/libraries/google/orgpolicy/property/policy_alternate_spec_rules.rb
@@ -13,12 +13,12 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec_rules_condition'
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec_rules_values'
+require 'google/orgpolicy/property/policy_alternate_spec_rules_condition'
+require 'google/orgpolicy/property/policy_alternate_spec_rules_values'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyAlternateSpecRules
+      class PolicyAlternateSpecRules
         attr_reader :condition
 
         attr_reader :deny_all
@@ -32,23 +32,23 @@ module GoogleInSpec
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @condition = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternateSpecRulesCondition.new(args['condition'], to_s)
+          @condition = GoogleInSpec::Orgpolicy::Property::PolicyAlternateSpecRulesCondition.new(args['condition'], to_s)
           @deny_all = args['denyAll']
           @allow_all = args['allowAll']
           @enforce = args['enforce']
-          @values = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternateSpecRulesValues.new(args['values'], to_s)
+          @values = GoogleInSpec::Orgpolicy::Property::PolicyAlternateSpecRulesValues.new(args['values'], to_s)
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyAlternateSpecRules"
+          "#{@parent_identifier} PolicyAlternateSpecRules"
         end
       end
 
-      class OrganizationPolicyAlternateSpecRulesArray
+      class PolicyAlternateSpecRulesArray
         def self.parse(value, parent_identifier)
           return if value.nil?
-          return OrganizationPolicyAlternateSpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
-          value.map { |v| OrganizationPolicyAlternateSpecRules.new(v, parent_identifier) }
+          return PolicyAlternateSpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
+          value.map { |v| PolicyAlternateSpecRules.new(v, parent_identifier) }
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_alternate_spec_rules_condition.rb
+++ b/libraries/google/orgpolicy/property/policy_alternate_spec_rules_condition.rb
@@ -16,7 +16,7 @@
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyDryRunSpecRulesCondition
+      class PolicyAlternateSpecRulesCondition
         attr_reader :title
 
         attr_reader :location
@@ -35,7 +35,7 @@ module GoogleInSpec
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyDryRunSpecRulesCondition"
+          "#{@parent_identifier} PolicyAlternateSpecRulesCondition"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_alternate_spec_rules_values.rb
+++ b/libraries/google/orgpolicy/property/policy_alternate_spec_rules_values.rb
@@ -13,33 +13,23 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicySpec
-        attr_reader :update_time
+      class PolicyAlternateSpecRulesValues
+        attr_reader :denied_values
 
-        attr_reader :rules
-
-        attr_reader :etag
-
-        attr_reader :reset
-
-        attr_reader :inherit_from_parent
+        attr_reader :allowed_values
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @update_time = args['updateTime']
-          @rules = GoogleInSpec::Orgpolicy::Property::OrganizationPolicySpecRulesArray.parse(args['rules'], to_s)
-          @etag = args['etag']
-          @reset = args['reset']
-          @inherit_from_parent = args['inheritFromParent']
+          @denied_values = args['deniedValues']
+          @allowed_values = args['allowedValues']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicySpec"
+          "#{@parent_identifier} PolicyAlternateSpecRulesValues"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_dry_run_spec.rb
+++ b/libraries/google/orgpolicy/property/policy_dry_run_spec.rb
@@ -13,23 +13,33 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
+require 'google/orgpolicy/property/policy_dry_run_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyAlternateSpecRulesValues
-        attr_reader :denied_values
+      class PolicyDryRunSpec
+        attr_reader :update_time
 
-        attr_reader :allowed_values
+        attr_reader :rules
+
+        attr_reader :etag
+
+        attr_reader :reset
+
+        attr_reader :inherit_from_parent
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @denied_values = args['deniedValues']
-          @allowed_values = args['allowedValues']
+          @update_time = args['updateTime']
+          @rules = GoogleInSpec::Orgpolicy::Property::PolicyDryRunSpecRulesArray.parse(args['rules'], to_s)
+          @etag = args['etag']
+          @reset = args['reset']
+          @inherit_from_parent = args['inheritFromParent']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyAlternateSpecRulesValues"
+          "#{@parent_identifier} PolicyDryRunSpec"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_dry_run_spec_rules.rb
+++ b/libraries/google/orgpolicy/property/policy_dry_run_spec_rules.rb
@@ -13,12 +13,12 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_spec_rules_condition'
-require 'google/orgpolicy/property/organizationpolicy_spec_rules_values'
+require 'google/orgpolicy/property/policy_dry_run_spec_rules_condition'
+require 'google/orgpolicy/property/policy_dry_run_spec_rules_values'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicySpecRules
+      class PolicyDryRunSpecRules
         attr_reader :condition
 
         attr_reader :deny_all
@@ -32,23 +32,23 @@ module GoogleInSpec
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @condition = GoogleInSpec::Orgpolicy::Property::OrganizationPolicySpecRulesCondition.new(args['condition'], to_s)
+          @condition = GoogleInSpec::Orgpolicy::Property::PolicyDryRunSpecRulesCondition.new(args['condition'], to_s)
           @deny_all = args['denyAll']
           @allow_all = args['allowAll']
           @enforce = args['enforce']
-          @values = GoogleInSpec::Orgpolicy::Property::OrganizationPolicySpecRulesValues.new(args['values'], to_s)
+          @values = GoogleInSpec::Orgpolicy::Property::PolicyDryRunSpecRulesValues.new(args['values'], to_s)
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicySpecRules"
+          "#{@parent_identifier} PolicyDryRunSpecRules"
         end
       end
 
-      class OrganizationPolicySpecRulesArray
+      class PolicyDryRunSpecRulesArray
         def self.parse(value, parent_identifier)
           return if value.nil?
-          return OrganizationPolicySpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
-          value.map { |v| OrganizationPolicySpecRules.new(v, parent_identifier) }
+          return PolicyDryRunSpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
+          value.map { |v| PolicyDryRunSpecRules.new(v, parent_identifier) }
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_dry_run_spec_rules_condition.rb
+++ b/libraries/google/orgpolicy/property/policy_dry_run_spec_rules_condition.rb
@@ -13,25 +13,29 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec'
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyAlternate
-        attr_reader :launch
+      class PolicyDryRunSpecRulesCondition
+        attr_reader :title
 
-        attr_reader :spec
+        attr_reader :location
+
+        attr_reader :expression
+
+        attr_reader :description
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @launch = args['launch']
-          @spec = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternateSpec.new(args['spec'], to_s)
+          @title = args['title']
+          @location = args['location']
+          @expression = args['expression']
+          @description = args['description']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyAlternate"
+          "#{@parent_identifier} PolicyDryRunSpecRulesCondition"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_dry_run_spec_rules_values.rb
+++ b/libraries/google/orgpolicy/property/policy_dry_run_spec_rules_values.rb
@@ -16,7 +16,7 @@
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicySpecRulesValues
+      class PolicyDryRunSpecRulesValues
         attr_reader :denied_values
 
         attr_reader :allowed_values
@@ -29,7 +29,7 @@ module GoogleInSpec
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicySpecRulesValues"
+          "#{@parent_identifier} PolicyDryRunSpecRulesValues"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_spec.rb
+++ b/libraries/google/orgpolicy/property/policy_spec.rb
@@ -13,11 +13,11 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec_rules'
+require 'google/orgpolicy/property/policy_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyAlternateSpec
+      class PolicySpec
         attr_reader :update_time
 
         attr_reader :rules
@@ -32,14 +32,14 @@ module GoogleInSpec
           return if args.nil?
           @parent_identifier = parent_identifier
           @update_time = args['updateTime']
-          @rules = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternateSpecRulesArray.parse(args['rules'], to_s)
+          @rules = GoogleInSpec::Orgpolicy::Property::PolicySpecRulesArray.parse(args['rules'], to_s)
           @etag = args['etag']
           @reset = args['reset']
           @inherit_from_parent = args['inheritFromParent']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyAlternateSpec"
+          "#{@parent_identifier} PolicySpec"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_spec_rules.rb
+++ b/libraries/google/orgpolicy/property/policy_spec_rules.rb
@@ -13,12 +13,12 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_dry_run_spec_rules_condition'
-require 'google/orgpolicy/property/organizationpolicy_dry_run_spec_rules_values'
+require 'google/orgpolicy/property/policy_spec_rules_condition'
+require 'google/orgpolicy/property/policy_spec_rules_values'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyDryRunSpecRules
+      class PolicySpecRules
         attr_reader :condition
 
         attr_reader :deny_all
@@ -32,23 +32,23 @@ module GoogleInSpec
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @condition = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyDryRunSpecRulesCondition.new(args['condition'], to_s)
+          @condition = GoogleInSpec::Orgpolicy::Property::PolicySpecRulesCondition.new(args['condition'], to_s)
           @deny_all = args['denyAll']
           @allow_all = args['allowAll']
           @enforce = args['enforce']
-          @values = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyDryRunSpecRulesValues.new(args['values'], to_s)
+          @values = GoogleInSpec::Orgpolicy::Property::PolicySpecRulesValues.new(args['values'], to_s)
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyDryRunSpecRules"
+          "#{@parent_identifier} PolicySpecRules"
         end
       end
 
-      class OrganizationPolicyDryRunSpecRulesArray
+      class PolicySpecRulesArray
         def self.parse(value, parent_identifier)
           return if value.nil?
-          return OrganizationPolicyDryRunSpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
-          value.map { |v| OrganizationPolicyDryRunSpecRules.new(v, parent_identifier) }
+          return PolicySpecRules.new(value, parent_identifier) unless value.is_a?(::Array)
+          value.map { |v| PolicySpecRules.new(v, parent_identifier) }
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_spec_rules_condition.rb
+++ b/libraries/google/orgpolicy/property/policy_spec_rules_condition.rb
@@ -16,7 +16,7 @@
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyAlternateSpecRulesCondition
+      class PolicySpecRulesCondition
         attr_reader :title
 
         attr_reader :location
@@ -35,7 +35,7 @@ module GoogleInSpec
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyAlternateSpecRulesCondition"
+          "#{@parent_identifier} PolicySpecRulesCondition"
         end
       end
     end

--- a/libraries/google/orgpolicy/property/policy_spec_rules_values.rb
+++ b/libraries/google/orgpolicy/property/policy_spec_rules_values.rb
@@ -13,33 +13,23 @@
 #     CONTRIBUTING.md located at the root of this package.
 #
 # ----------------------------------------------------------------------------
-require 'google/orgpolicy/property/organizationpolicy_dry_run_spec_rules'
 module GoogleInSpec
   module Orgpolicy
     module Property
-      class OrganizationPolicyDryRunSpec
-        attr_reader :update_time
+      class PolicySpecRulesValues
+        attr_reader :denied_values
 
-        attr_reader :rules
-
-        attr_reader :etag
-
-        attr_reader :reset
-
-        attr_reader :inherit_from_parent
+        attr_reader :allowed_values
 
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
-          @update_time = args['updateTime']
-          @rules = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyDryRunSpecRulesArray.parse(args['rules'], to_s)
-          @etag = args['etag']
-          @reset = args['reset']
-          @inherit_from_parent = args['inheritFromParent']
+          @denied_values = args['deniedValues']
+          @allowed_values = args['allowedValues']
         end
 
         def to_s
-          "#{@parent_identifier} OrganizationPolicyDryRunSpec"
+          "#{@parent_identifier} PolicySpecRulesValues"
         end
       end
     end

--- a/libraries/google_orgpolicy_organization_policies.rb
+++ b/libraries/google_orgpolicy_organization_policies.rb
@@ -66,10 +66,10 @@ class OrgpolicyOrganizationPolicys < GcpResourceBase
 
   def transformers
     {
-      'dryRunSpec' => ->(obj) { [:dry_run_spec, GoogleInSpec::Orgpolicy::Property::OrganizationPolicyDryRunSpec.new(obj['dryRunSpec'], to_s)] },
-      'spec' => ->(obj) { [:spec, GoogleInSpec::Orgpolicy::Property::OrganizationPolicySpec.new(obj['spec'], to_s)] },
+      'dryRunSpec' => ->(obj) { [:dry_run_spec, GoogleInSpec::Orgpolicy::Property::PolicyDryRunSpec.new(obj['dryRunSpec'], to_s)] },
+      'spec' => ->(obj) { [:spec, GoogleInSpec::Orgpolicy::Property::PolicySpec.new(obj['spec'], to_s)] },
       'name' => ->(obj) { [:name, obj['name']] },
-      'alternate' => ->(obj) { [:alternate, GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternate.new(obj['alternate'], to_s)] },
+      'alternate' => ->(obj) { [:alternate, GoogleInSpec::Orgpolicy::Property::PolicyAlternate.new(obj['alternate'], to_s)] },
     }
   end
 

--- a/libraries/google_orgpolicy_organization_policy.rb
+++ b/libraries/google_orgpolicy_organization_policy.rb
@@ -14,13 +14,13 @@
 #
 # ----------------------------------------------------------------------------
 require 'gcp_backend'
-require 'google/orgpolicy/property/organizationpolicy_alternate'
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec'
-require 'google/orgpolicy/property/organizationpolicy_alternate_spec_rules'
-require 'google/orgpolicy/property/organizationpolicy_dry_run_spec'
-require 'google/orgpolicy/property/organizationpolicy_dry_run_spec_rules'
-require 'google/orgpolicy/property/organizationpolicy_spec'
-require 'google/orgpolicy/property/organizationpolicy_spec_rules'
+require 'google/orgpolicy/property/policy_alternate'
+require 'google/orgpolicy/property/policy_alternate_spec'
+require 'google/orgpolicy/property/policy_alternate_spec_rules'
+require 'google/orgpolicy/property/policy_dry_run_spec'
+require 'google/orgpolicy/property/policy_dry_run_spec_rules'
+require 'google/orgpolicy/property/policy_spec'
+require 'google/orgpolicy/property/policy_spec_rules'
 
 # A provider to manage orgpolicy resources.
 class OrgpolicyOrganizationPolicy < GcpResourceBase
@@ -42,10 +42,10 @@ class OrgpolicyOrganizationPolicy < GcpResourceBase
   end
 
   def parse
-    @dry_run_spec = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyDryRunSpec.new(@fetched['dryRunSpec'], to_s)
-    @spec = GoogleInSpec::Orgpolicy::Property::OrganizationPolicySpec.new(@fetched['spec'], to_s)
+    @dry_run_spec = GoogleInSpec::Orgpolicy::Property::PolicyDryRunSpec.new(@fetched['dryRunSpec'], to_s)
+    @spec = GoogleInSpec::Orgpolicy::Property::PolicySpec.new(@fetched['spec'], to_s)
     @name = @fetched['name']
-    @alternate = GoogleInSpec::Orgpolicy::Property::OrganizationPolicyAlternate.new(@fetched['alternate'], to_s)
+    @alternate = GoogleInSpec::Orgpolicy::Property::PolicyAlternate.new(@fetched['alternate'], to_s)
   end
 
   def exists?


### PR DESCRIPTION
### Description

Renaming orgpolicy properties to reuse the same properties for other org policy resources

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
