### PR TITLE
Add boot_disk_kms_key attribute for gke node pool

### DIFF
--- a/docs/resources/google_container_node_pool.md
+++ b/docs/resources/google_container_node_pool.md
@@ -52,6 +52,12 @@ end
       its('initial_node_count'){should eq 3}
     end
 
+### Test GCP container node pool boot disk kms key is as expected
+
+    describe google_container_node_pool(project: 'chef-inspec-gcp', locations: 'europe-west2-a', cluster_name: 'inspec-gcp-kube-cluster', nodepool_name: 'inspec-gcp-kube-node-pool') do
+      its('config.boot_disk_kms_key'){should eq "projects/1234567890/locations/europe-west2-a/keyRings/inspec-gcp-kube-cluster-keyring/cryptoKeys/inspec-gcp-kube-cluster-key"}
+    end
+
 ## Properties
 Properties that can be accessed from the `google_container_node_pool` resource:
 
@@ -110,6 +116,8 @@ Properties that can be accessed from the `google_container_node_pool` resource:
       Possible values:
         * GCE_METADATA
         * GKE_METADATA
+
+    * `boot_disk_kms_key`: The Cloud KMS key to use for the boot disk attached to each node in the node pool.
 
   * `initial_node_count`: The initial node count for the pool. You must ensure that your Compute Engine resource quota is sufficient for this number of instances. You must also have available firewall and routes quota.
 

--- a/libraries/google/container/property/nodepool_config.rb
+++ b/libraries/google/container/property/nodepool_config.rb
@@ -53,6 +53,8 @@ module GoogleInSpec
 
         attr_reader :workload_meta_config
 
+        attr_reader :boot_disk_kms_key
+
         def initialize(args = nil, parent_identifier = nil)
           return if args.nil?
           @parent_identifier = parent_identifier
@@ -72,6 +74,7 @@ module GoogleInSpec
           @taints = GoogleInSpec::Container::Property::NodePoolConfigTaintsArray.parse(args['taints'], to_s)
           @shielded_instance_config = GoogleInSpec::Container::Property::NodePoolConfigShieldedInstanceConfig.new(args['shieldedInstanceConfig'], to_s)
           @workload_meta_config = GoogleInSpec::Container::Property::NodePoolConfigWorkloadMetaConfig.new(args['workloadMetadataConfig'], to_s)
+          @boot_disk_kms_key = args['bootDiskKmsKey']
         end
 
         def to_s


### PR DESCRIPTION
### Description
This change adds support for verifying the bootDiskKmsKey attribute in Google Kubernetes Engine (GKE) node pool configurations.
gcloud command:
`gcloud container node-pools describe <node-pool> --cluster <cluster> --region <region> --format='value(config.bootDiskKmsKey')`

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec GCP](https://github.com/inspec/inspec-gcp/CONTRIBUTING.md) document before 
submitting.

### Issues Resolved
Missing attribute coverage: Resolves the gap in node pool configuration verification by adding support for `bootDiskKmsKey` attribute

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant.

Please ensure commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
